### PR TITLE
Feat emotibit cross version compatibility

### DIFF
--- a/EdaCorrection.cpp
+++ b/EdaCorrection.cpp
@@ -585,7 +585,7 @@ EdaCorrection::Status EdaCorrection::writeToOtp(Si7013* si7013)
 	}
 }
 
-uint8_t EdaCorrection::readEmotiBitVersion(Si7013* si7013)
+int EdaCorrection::readEmotiBitVersion(Si7013* si7013)
 {
 	if (checkSensorConnection(si7013) == false)
 	{
@@ -605,8 +605,9 @@ uint8_t EdaCorrection::readEmotiBitVersion(Si7013* si7013)
 		else
 		{
 			Serial.println("######################");
-			Serial.print("The Version read from OTP is: ");
-			Serial.println(emotibitVersion);
+			Serial.print("The EmotiBit Version read from OTP is: ");
+			Serial.println(EmotiBitVersionController::getHardwareVersion((EmotiBitVersionController::EmotiBitVersion)emotibitVersion));
+			//Serial.println(EmotiBitemotibitVersion);
 			Serial.println("######################");
 		}
 		return emotibitVersion;

--- a/EdaCorrection.cpp
+++ b/EdaCorrection.cpp
@@ -598,10 +598,17 @@ uint8_t EdaCorrection::readEmotiBitVersion(Si7013* si7013)
 		// Sensor found
 		uint8_t emotibitVersion = 0;
 		emotibitVersion = (uint8_t)si7013->readRegister8(otpMemoryMap.emotiBitVersionAddr, true);
-		Serial.println("######################");
-		Serial.print("The Version read from EmotiBit is: ");
-		Serial.println(emotibitVersion);
-		Serial.println("######################");
+		if (emotibitVersion == 255)
+		{
+			Serial.println("OTP has not yet been updated");
+		}
+		else
+		{
+			Serial.println("######################");
+			Serial.print("The Version read from OTP is: ");
+			Serial.println(emotibitVersion);
+			Serial.println("######################");
+		}
 		return emotibitVersion;
 	}
 }

--- a/EdaCorrection.h
+++ b/EdaCorrection.h
@@ -51,7 +51,7 @@ NORMAL
 #include "Arduino.h"
 #include "Wire.h"
 #include "EmotiBit_Si7013.h"
-
+#include "EmotiBitVersionController.h"
 //#define USE_ALT_SI7013
 #define ACCESS_MAIN_ADDRESS
 
@@ -237,7 +237,7 @@ public:
 	/*
 	Returns the emotiBit version read from the OTP
 	*/
-	uint8_t readEmotiBitVersion(Si7013* si7013);
+	int readEmotiBitVersion(Si7013* si7013);
 
 	//uint8_t readFromOtp(TwoWire* emotibit_i2c, uint8_t addr);
 	/*

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -238,13 +238,10 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	emotiBitVersionController.emotiBitPinMapping.echoPinMapping();
 	emotiBitVersionController.emotiBitConstantsMapping.echoConstants();
 #endif
-	//Serial.println("pausing execution. Please check the mappings above");
-	//while (1);
 
 	bool status = true;
 
 	SamdStorageAdcValues samdStorageAdcValues;
-	//EmotiBitPinMapping emotiBitPinMapping;
 	String fwVersionModifier = "";
 	if (testingMode == TestingMode::ACUTE)
 	{
@@ -428,8 +425,6 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	Serial.print("edrAmplification = "); Serial.println(edrAmplification);
 	Serial.print("LED Driver Current Level = "); Serial.println(emotiBitVersionController.emotiBitConstantsMapping.getSystemConstant(EmotiBitVersionController::EmotiBitConstantsMapping::SystemConstants::LED_DRIVER_CURRENT));
 
-	//Serial.println("check pin asignment. Stopping execution");
-	//while (1);
 	// Setup switch
 	if (buttonPin != LED_BUILTIN)
 	{
@@ -440,37 +435,6 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 
 	// Setup battery Reading
 	pinMode(_batteryReadPin, INPUT);
-
-	//// Enable analog circuitry
-	//Serial.print("\nCycling EmotiBit power...");
-	//pinMode(_hibernatePin, OUTPUT);
-	//if (_version == EmotiBitVersionController::EmotiBitVersion::V03B)
-	//{
-	//	digitalWrite(_hibernatePin, LOW);
-	//	Serial.print("Made pin "); Serial.print(_hibernatePin); Serial.println(" LOW");
-	//}
-	//else
-	//{
-	//	digitalWrite(_hibernatePin, HIGH);
-	//	Serial.print("Made pin "); Serial.print(_hibernatePin); Serial.println(" HIGH");
-	//}
-
-	//delay(250);
-
-	//// Enable analog circuitry
-	//Serial.print("Enabling EmotiBit power...");
-	////pinMode(_hibernatePin, OUTPUT);
-	//if (_version == EmotiBitVersionController::EmotiBitVersion::V03B)
-	//{
-	//	digitalWrite(_hibernatePin, HIGH);
-	//	Serial.print("Made pin "); Serial.print(_hibernatePin); Serial.println(" HIGH");
-	//}
-	//else
-	//{
-	//	digitalWrite(_hibernatePin, LOW);
-	//	Serial.print("Made pin "); Serial.print(_hibernatePin); Serial.println(" LOW");
-	//}
-
 	Serial.println("\nSensor setup:");
 	// Setup EDA
 	Serial.println("Configuring EDA...");
@@ -494,16 +458,12 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 			Serial.println("Reading correction data from the flash");
 			Serial.println("Calculating correction values");
 			adcCorrection.calcCorrectionValues();
-			// ToDo: check if above function actually worked
 			// Store the values on the flash
 			Serial.println("Storing correction values on the SAMD flash");
 			samdStorageAdcValues._gainCorrection = adcCorrection.getGainCorrection();
 			samdStorageAdcValues._offsetCorrection = adcCorrection.getOffsetCorrection();
 			samdStorageAdcValues.valid = true;
 			samdFlashStorage.write(samdStorageAdcValues);// Writing it to the SAMD flash storage
-			// reinitializing the wifi module
-			/*WiFi.setPins(8, 7, 4, 2);
-			nm_bsp_init();*/
 			Serial.print("Gain Correction:"); Serial.print(samdStorageAdcValues._gainCorrection); Serial.print("\toffset correction:"); Serial.println(samdStorageAdcValues._offsetCorrection);
 			Serial.println("Enabling the ADC with the correction values");
 			analogReadCorrection(samdStorageAdcValues._offsetCorrection, samdStorageAdcValues._gainCorrection);
@@ -520,10 +480,6 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 
 	
 	Serial.print("\n");
-	//_EmotiBit_i2c->endTransmission();
-	//_EmotiBit_i2c->clearWriteError();
-	//_EmotiBit_i2c->end();
-
 	// setup LED DRIVER
 	Serial.println("Initializing NCP5623....");
 	led.begin(*_EmotiBit_i2c);
@@ -532,16 +488,6 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	{
 		led.setCurrent(emotiBitVersionController.emotiBitConstantsMapping.getSystemConstant(EmotiBitVersionController::EmotiBitConstantsMapping::SystemConstants::LED_DRIVER_CURRENT));
 	}
-	/*
-	if (_version == EmotiBitVersionController::EmotiBitVersion::V03B)
-	{
-		led.setCurrent(6); // V03B has a Reference current resistor as 200K. Level 6/30 controls the max brightness of the LEDs
-	}
-	else
-	{
-		led.setCurrent(26);  // Version < V03B has a Reference current resistor as 1M. Level 26/30 controls the max brightness of the LEDs
-	}
-	*/
 	led.setLEDpwm((uint8_t)Led::RED, 8);
 	led.setLEDpwm((uint8_t)Led::BLUE, 8);
 	led.setLEDpwm((uint8_t)Led::YELLOW, 8);
@@ -2779,16 +2725,6 @@ void EmotiBit::hibernate() {
 	Serial.println("Disabling EmotiBit power");
 	pinMode(_hibernatePin, OUTPUT);
 	digitalWrite(_hibernatePin, emotiBitVersionController.emotiBitConstantsMapping.getSystemConstant(EmotiBitVersionController::EmotiBitConstantsMapping::SystemConstants::EMOTIBIT_HIBERNATE_LEVEL));
-	/*
-	if (_version == EmotiBitVersionController::EmotiBitVersion::V03B)
-	{
-		digitalWrite(_hibernatePin, LOW);
-	}
-	else
-	{
-		digitalWrite(_hibernatePin, HIGH);
-	}
-	*/
 	pinMode(_hibernatePin, INPUT);
 
 	//deepSleep();

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -37,7 +37,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.20";
+	String firmware_version = "1.2.21";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 
@@ -347,6 +347,7 @@ public:
 	bool _sendTestData = false;
 	float _edlDigFiltAlpha = 0;
 	float _edlDigFilteredVal = -1;
+	float _edaSeriesResistance = 0;
 	DataType _serialData = DataType::length;
 	volatile bool buttonPressed = false;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -21,7 +21,7 @@
 #include <ArduinoLowPower.h>
 #include "AdcCorrection.h"
 #include "EdaCorrection.h"
-//#include "EmotiBitPinMapping.h"
+#include "EmotiBitVersionController.h"
 
 //#include <Adafruit_SleepyDog.h>
 
@@ -37,7 +37,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.19";
+	String firmware_version = "1.2.20";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 
@@ -52,6 +52,7 @@ public:
 
 	// !!! The following ORDER of the enum class holding the Version numbers SHOULD NOT BE ALTERED.
 	// New versions shold be ADDED to the end of this list 
+	/*
 	enum class Version {
 		V01B = 0,
 		V01C = 1,
@@ -60,7 +61,7 @@ public:
 		V02H = 4,
 		V03B = 5
 	};
-
+	*/
 	//struct IMUSettings {
 	//int gyroResolution = 250;
 	//int accResolution = 2;
@@ -225,6 +226,7 @@ public:
 	NCP5623 led;
 	MLX90632 thermopile;
 	EdaCorrection edaCorrection;
+	EmotiBitVersionController emotiBitVersionController;
 
 	float edrAmplification;
 	float vRef1; // Reference voltage of first voltage divider(15/100)
@@ -474,7 +476,8 @@ private:
 	uint8_t _adcBits;
 	float _accelerometerRange; // supported values: 2, 4, 8, 16 (G)
 	float _gyroRange; // supported values: 125, 250, 500, 1000, 2000 (degrees/second)
-	Version _version;
+	//Version _version;
+	EmotiBitVersionController::EmotiBitVersion _version;
 	uint8_t _imuFifoFrameLen = 0; // in bytes
 	const uint8_t _maxImuFifoFrameLen = 40; // in bytes
 	uint8_t _imuBuffer[40];

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -21,6 +21,7 @@
 #include <ArduinoLowPower.h>
 #include "AdcCorrection.h"
 #include "EdaCorrection.h"
+//#include "EmotiBitPinMapping.h"
 
 //#include <Adafruit_SleepyDog.h>
 
@@ -36,7 +37,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.17";
+	String firmware_version = "1.2.18";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 
@@ -224,6 +225,7 @@ public:
 	NCP5623 led;
 	MLX90632 thermopile;
 	EdaCorrection edaCorrection;
+
 	float edrAmplification;
 	float vRef1; // Reference voltage of first voltage divider(15/100)
 	float vRef2; // Reference voltage from second voltage divider(100/100)
@@ -418,6 +420,7 @@ public:
 	void sendModePacket(String &sentModePacket, uint16_t &packetNumber);
 	void processDebugInputs(String &debugPackets, uint16_t &packetNumber);
 	String getHardwareVersion();
+	int detectEmotiBitVersion();
 
 	// ----------- END ino refactoring ---------------
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -37,7 +37,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.21";
+	String firmware_version = "1.2.22";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -37,7 +37,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.18";
+	String firmware_version = "1.2.19";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 
@@ -426,7 +426,7 @@ public:
 
 	
   EmotiBit();
-  uint8_t setup(Version version = Version::V02H, size_t bufferCapacity = 64);   /**< Setup all the sensors */
+  uint8_t setup(size_t bufferCapacity = 64);   /**< Setup all the sensors */
 	uint8_t update();
   void setAnalogEnablePin(uint8_t i); /**< Power on/off the analog circuitry */
   int8_t updateIMUData();                /**< Read any available IMU data from the sensor FIFO into the inputBuffers */

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -11,6 +11,22 @@ const char* EmotiBitVersionController::getHardwareVersion(EmotiBitVersion versio
 	{
 		return "V03b";
 	}
+	else if (version == EmotiBitVersion::V01B)
+	{
+		return "V01b";
+	}
+	else if (version == EmotiBitVersion::V01C)
+	{
+		return "V01c";
+	}
+	else if (version == EmotiBitVersion::V02B)
+	{
+		return "V02b";
+	}
+	else if (version == EmotiBitVersion::V02F)
+	{
+		return "V02f";
+	}
 }
 
 bool EmotiBitVersionController::EmotiBitPinMapping::initMapping(EmotiBitVersionController::EmotiBitVersion version)

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -1,0 +1,253 @@
+#include "EmotiBitVersionController.h"
+#include "Arduino.h"
+
+const char* EmotiBitVersionController::getHardwareVersion(EmotiBitVersion version)
+{
+	if (version == EmotiBitVersion::V02H) 
+	{
+		return "V02h";
+	}
+	else if (version == EmotiBitVersion::V03B)
+	{
+		return "V03b";
+	}
+}
+
+bool EmotiBitVersionController::EmotiBitPinMapping::initMapping(EmotiBitVersionController::EmotiBitVersion version)
+{
+#if defined(ADAFRUIT_FEATHER_M0)
+
+	_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::BATTERY_READ_PIN] = A7;
+	_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::SPI_CLK] = 24;
+	_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::SPI_MOSI] = 23;
+	_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::SPI_MISO] = 22;
+
+	if (version == EmotiBitVersionController::EmotiBitVersion::V02B || version == EmotiBitVersionController::EmotiBitVersion::V02H || version == EmotiBitVersionController::EmotiBitVersion::V03B)
+	{
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::HIBERNATE] = 6;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EMOTIBIT_BUTTON] = 12;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EDL] = A4;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EDR] = A3;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::SD_CARD_CHIP_SELECT] = 19;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EMOTIBIT_I2C_CLOCK] = 13;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EMOTIBTI_I2C_DATA] = 11;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::PPG_INT] = 15;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::BMI_INT1] = 5;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::BMI_INT2] = 10;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::BMM_INT] = 14;
+	}
+	else if (version == EmotiBitVersionController::EmotiBitVersion::V01B || version == EmotiBitVersionController::EmotiBitVersion::V01C)
+	{
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::HIBERNATE] = 5;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EMOTIBIT_BUTTON] = 13;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EDL] = A3;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EDR] = A4;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::SD_CARD_CHIP_SELECT] = 6;
+	}
+	else
+	{
+		// unknown version
+		return false;
+	}
+#elif defined(ADAFRUIT_BLUEFRUIT_NRF52_FEATHER)
+	if (version == EmotiBitVersionController::EmotiBitVersion::V01B || version == EmotiBitVersionController::EmotiBitVersion::V01C)
+	{
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::HIBERNATE] = 27;//gpio pin assigned ot the mosfet
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EMOTIBIT_BUTTON] = 16;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EDL] = A3; = A3;
+		_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EDR] = A4;
+	}
+	else
+	{
+		// unknown version
+		return false;
+	}
+#endif
+	return true;
+}
+
+int EmotiBitVersionController::EmotiBitPinMapping::getAssignedPin(EmotiBitPinMapping::EmotiBitPinName pin)
+{
+	if ((int)pin >= _MAX_EMOTIBIT_PIN_COUNT)
+	{
+		Serial.println("out of bounds pin accessed. Please check pin number again");
+		return -1;
+	}
+	else
+	{
+		return _assignedPin[(int)pin];
+	}
+}
+
+void EmotiBitVersionController::EmotiBitPinMapping::echoPinMapping()
+{
+	Serial.print("EMOTIBIT_I2C_CLOCK: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EMOTIBIT_I2C_CLOCK]);
+	Serial.print("EMOTIBTI_I2C_DATA: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EMOTIBTI_I2C_DATA]);
+	Serial.print("HIBERNATE: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::HIBERNATE]);
+	Serial.print("EMOTIBIT_BUTTON: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EMOTIBIT_BUTTON]);
+	Serial.print("EDL: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EDL]);
+	Serial.print("EDR: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::EDR]);
+	Serial.print("SD_CARD_CHIP_SELECT: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::SD_CARD_CHIP_SELECT]);
+	Serial.print("SPI_CLK: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::SPI_CLK]);
+	Serial.print("SPI_MOSI: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::SPI_MOSI]);
+	Serial.print("SPI_MISO: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::SPI_MISO]);
+	Serial.print("PPG_INT: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::PPG_INT]);
+	Serial.print("BMI_INT1: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::BMI_INT1]);
+	Serial.print("BMI_INT2: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::BMI_INT2]);
+	Serial.print("BMM_INT: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::BMM_INT]);
+	Serial.print("BATTERY_READ_PIN: "); Serial.println(_assignedPin[(int)EmotiBitPinMapping::EmotiBitPinName::BATTERY_READ_PIN]);
+
+}
+
+
+
+
+bool EmotiBitVersionController::EmotiBitConstantsMapping::initMapping(EmotiBitVersionController::EmotiBitVersion version)
+{
+	if (!_initMappingMathConstants(version))
+	{
+		return false;
+	}
+	if (!_initMappingSystemConstants(version))
+	{
+		return false;
+	}
+	return true;
+}
+
+bool EmotiBitVersionController::EmotiBitConstantsMapping::_initMappingMathConstants(EmotiBitVersionController::EmotiBitVersion version)
+{
+	if ((int)MathConstants::COUNT > (int)_MAX_MATH_CONSTANT_COUNT)
+	{
+		// more consatnts that the array has been initialized for
+		Serial.println("Out of bounds error for Math constants. please check total constant count with array memory allocation.");
+		return false;
+	}
+#if defined(ADAFRUIT_FEATHER_M0)
+	_assignedMathConstants[(int)MathConstants::VCC] = 3.3f;
+	_assignedMathConstants[(int)MathConstants::ADC_BITS] = 12;
+	_assignedMathConstants[(int)MathConstants::ADC_MAX_VALUE] = pow(2, _assignedMathConstants[(int)MathConstants::ADC_BITS]) - 1;;
+	
+	if (version == EmotiBitVersionController::EmotiBitVersion::V02H || version == EmotiBitVersionController::EmotiBitVersion::V03B)
+	{
+		_assignedMathConstants[(int)MathConstants::EDR_AMPLIFICATION] = 100.f / 3.3f;
+		_assignedMathConstants[(int)MathConstants::VREF1] = 0.426f; // empirically derived minimum voltage divider value [theoretical 15/(15 + 100)]
+		_assignedMathConstants[(int)MathConstants::VREF2] = 1.634591173; // empirically derived average voltage divider value [theoretical _vcc * (100.f / (100.f + 100.f))]
+		_assignedMathConstants[(int)MathConstants::EDA_FEEDBACK_R] = 5070000.f; // empirically derived average edaFeedbackAmpR in Ohms (theoretical 4990000.f)
+		_assignedMathConstants[(int)MathConstants::EDA_SERIES_RESISTOR] = 0;
+		if (version == EmotiBitVersionController::EmotiBitVersion::V02H)
+		{
+			_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ] = 1.f / (2.f * PI * 200000.f * 0.0000047f);
+		}
+		else
+		{
+			_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ] = _INVALID_MATH_CONSTANT_FOR_VERSION;
+		}
+	}
+	else if (version == EmotiBitVersionController::EmotiBitVersion::V02B)
+	{
+		_assignedMathConstants[(int)MathConstants::EDR_AMPLIFICATION] = 100.f / 1.2f;
+		_assignedMathConstants[(int)MathConstants::VREF1] = _INVALID_MATH_CONSTANT_FOR_VERSION;
+		_assignedMathConstants[(int)MathConstants::VREF2] = _INVALID_MATH_CONSTANT_FOR_VERSION;
+		_assignedMathConstants[(int)MathConstants::EDA_FEEDBACK_R] = 4990000.f;
+		_assignedMathConstants[(int)MathConstants::EDA_SERIES_RESISTOR] = _INVALID_MATH_CONSTANT_FOR_VERSION;
+		_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ] = _INVALID_MATH_CONSTANT_FOR_VERSION;
+	}
+	_initAssignmentComplete = true;
+	return true;
+#endif
+}
+
+bool EmotiBitVersionController::EmotiBitConstantsMapping::_initMappingSystemConstants(EmotiBitVersionController::EmotiBitVersion version)
+{
+	if ((int)SystemConstants::COUNT > (int)_MAX_SYSTEM_CONSTANT_COUNT)
+	{
+		Serial.println("Out of bounds error for System constants. please check total constant count with array memory allocation.");
+		return false;
+	}
+#if defined(ADAFRUIT_FEATHER_M0)
+	if (version == EmotiBitVersionController::EmotiBitVersion::V02H)
+	{
+		_assignedSystemConstants[(int)SystemConstants::EMOTIBIT_HIBERNATE_LEVEL] = HIGH;
+		_assignedSystemConstants[(int)SystemConstants::LED_DRIVER_CURRENT] = 26;
+	}
+	else if (version == EmotiBitVersionController::EmotiBitVersion::V03B)
+	{
+		_assignedSystemConstants[(int)SystemConstants::EMOTIBIT_HIBERNATE_LEVEL] = LOW;
+		_assignedSystemConstants[(int)SystemConstants::LED_DRIVER_CURRENT] = 6;
+	}
+	return true;
+#endif
+}
+
+float EmotiBitVersionController::EmotiBitConstantsMapping::getMathConstant(EmotiBitVersionController::EmotiBitConstantsMapping::MathConstants constant)
+{
+	if (_initAssignmentComplete)
+	{
+		if ((int)constant >= _MAX_MATH_CONSTANT_COUNT)
+		{
+			Serial.println("Invalid request");
+			return _INVALID_REQUEST;
+		}
+		else
+		{
+			return _assignedMathConstants[(int)constant];
+		}
+	}
+	else
+	{
+		Serial.println("Constants not initialized yet. call emotiBitVersionController.emotibitConstantMapping.initMapping()");
+		return _INVALID_REQUEST;
+	}
+}
+
+int EmotiBitVersionController::EmotiBitConstantsMapping::getSystemConstant(EmotiBitVersionController::EmotiBitConstantsMapping::SystemConstants constant)
+{
+	if (_initAssignmentComplete)
+	{
+		if ((int)constant >= _MAX_SYSTEM_CONSTANT_COUNT)
+		{
+			Serial.println("Invalid request");
+			return _INVALID_REQUEST;
+		}
+		else
+		{
+			return _assignedSystemConstants[(int)constant];
+		}
+	}
+	else
+	{
+		Serial.println("Constants not initialized yet.  call emotiBitVersionController.emotibitConstantMapping.initMapping()");
+		return _INVALID_REQUEST;
+	}
+}
+
+void EmotiBitVersionController::EmotiBitConstantsMapping::echoConstants()
+{
+	if (_initAssignmentComplete)
+	{
+		Serial.print("MathConstants: VCC - "); Serial.println(_assignedMathConstants[(int)MathConstants::VCC]);
+		Serial.print("MathConstants: ADC_BITS - "); Serial.println(_assignedMathConstants[(int)MathConstants::ADC_BITS]);
+		Serial.print("MathConstants: ADC_MAX_VALUE - "); Serial.println(_assignedMathConstants[(int)MathConstants::ADC_MAX_VALUE]);
+		Serial.print("MathConstants: EDR_AMPLIFICATION - "); Serial.println(_assignedMathConstants[(int)MathConstants::EDR_AMPLIFICATION]);
+		Serial.print("MathConstants: VREF1 - "); Serial.println(_assignedMathConstants[(int)MathConstants::VREF1]);
+		Serial.print("MathConstants: VREF2 - "); Serial.println(_assignedMathConstants[(int)MathConstants::VREF2]);
+		Serial.print("MathConstants: EDA_FEEDBACK_R - "); Serial.println(_assignedMathConstants[(int)MathConstants::EDA_FEEDBACK_R]);
+		Serial.print("MathConstants: EDA_CROSSOVER_FILTER_FREQ - "); Serial.println(_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ]);
+		Serial.print("MathConstants: EDA_SERIES_RESISTOR - "); Serial.println(_assignedMathConstants[(int)MathConstants::EDA_SERIES_RESISTOR]);
+	}
+	else
+	{
+		Serial.println("Please initilize the constants.  call emotiBitVersionController.emotibitConstantMapping.initMapping()");
+	}
+}
+
+bool EmotiBitVersionController::EmotiBitConstantsMapping::setMathConstantForTesting(EmotiBitVersionController::EmotiBitConstantsMapping::MathConstants constant)
+{
+	//ToDo: write the function to assign test values to the constants 
+}
+
+bool EmotiBitVersionController::EmotiBitConstantsMapping::setSystemConstantForTesting(EmotiBitVersionController::EmotiBitConstantsMapping::SystemConstants constant)
+{
+	//ToDo: write the function to assign test values to the constants 
+}

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -135,23 +135,17 @@ bool EmotiBitVersionController::EmotiBitConstantsMapping::_initMappingMathConsta
 		_assignedMathConstants[(int)MathConstants::VREF2] = 1.634591173; // empirically derived average voltage divider value [theoretical _vcc * (100.f / (100.f + 100.f))]
 		_assignedMathConstants[(int)MathConstants::EDA_FEEDBACK_R] = 5070000.f; // empirically derived average edaFeedbackAmpR in Ohms (theoretical 4990000.f)
 		_assignedMathConstants[(int)MathConstants::EDA_SERIES_RESISTOR] = 0;
-		if (version == EmotiBitVersionController::EmotiBitVersion::V02H)
-		{
-			_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ] = 1.f / (2.f * PI * 200000.f * 0.0000047f);
-		}
-		else
-		{
-			_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ] = _INVALID_MATH_CONSTANT_FOR_VERSION;
-		}
+		_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ] = 1.f / (2.f * PI * 200000.f * 0.0000047f);
+		
 	}
 	else if (version == EmotiBitVersionController::EmotiBitVersion::V02B)
 	{
 		_assignedMathConstants[(int)MathConstants::EDR_AMPLIFICATION] = 100.f / 1.2f;
-		_assignedMathConstants[(int)MathConstants::VREF1] = _INVALID_MATH_CONSTANT_FOR_VERSION;
-		_assignedMathConstants[(int)MathConstants::VREF2] = _INVALID_MATH_CONSTANT_FOR_VERSION;
+		_assignedMathConstants[(int)MathConstants::VREF1] = _INVALID_CONSTANT_FOR_VERSION;
+		_assignedMathConstants[(int)MathConstants::VREF2] = _INVALID_CONSTANT_FOR_VERSION;
 		_assignedMathConstants[(int)MathConstants::EDA_FEEDBACK_R] = 4990000.f;
-		_assignedMathConstants[(int)MathConstants::EDA_SERIES_RESISTOR] = _INVALID_MATH_CONSTANT_FOR_VERSION;
-		_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ] = _INVALID_MATH_CONSTANT_FOR_VERSION;
+		_assignedMathConstants[(int)MathConstants::EDA_SERIES_RESISTOR] = _INVALID_CONSTANT_FOR_VERSION;
+		_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ] = _INVALID_CONSTANT_FOR_VERSION;
 	}
 	_initAssignmentComplete = true;
 	return true;
@@ -175,6 +169,11 @@ bool EmotiBitVersionController::EmotiBitConstantsMapping::_initMappingSystemCons
 	{
 		_assignedSystemConstants[(int)SystemConstants::EMOTIBIT_HIBERNATE_LEVEL] = LOW;
 		_assignedSystemConstants[(int)SystemConstants::LED_DRIVER_CURRENT] = 6;
+	}
+	else if (version == EmotiBitVersionController::EmotiBitVersion::V02B)
+	{
+		_assignedSystemConstants[(int)SystemConstants::EMOTIBIT_HIBERNATE_LEVEL] = HIGH;
+		_assignedSystemConstants[(int)SystemConstants::LED_DRIVER_CURRENT] = _INVALID_CONSTANT_FOR_VERSION;
 	}
 	return true;
 #endif
@@ -235,6 +234,8 @@ void EmotiBitVersionController::EmotiBitConstantsMapping::echoConstants()
 		Serial.print("MathConstants: EDA_FEEDBACK_R - "); Serial.println(_assignedMathConstants[(int)MathConstants::EDA_FEEDBACK_R]);
 		Serial.print("MathConstants: EDA_CROSSOVER_FILTER_FREQ - "); Serial.println(_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ]);
 		Serial.print("MathConstants: EDA_SERIES_RESISTOR - "); Serial.println(_assignedMathConstants[(int)MathConstants::EDA_SERIES_RESISTOR]);
+		Serial.print("SystemConstant: EMOTIBIT_HIBERNATE_LEVEL - "); Serial.println(_assignedSystemConstants[(int)SystemConstants::EMOTIBIT_HIBERNATE_LEVEL]);
+		Serial.print("SystemConstant: LED_DRIVER_CURRENT - "); Serial.println(_assignedSystemConstants[(int)SystemConstants::LED_DRIVER_CURRENT]);
 	}
 	else
 	{

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -1,0 +1,112 @@
+// the Emotibit Pin mapping class handles mapping of the Feather pin number to the EmotiBit pin name
+// Author : Nitin
+// date: 17 Feb 2021
+
+#ifndef _EMOTIBIT_PIN_MAPPING_H
+#define _EMOTIBIT_PIN_MAPPING_H
+
+
+class EmotiBitVersionController
+{
+public:
+	// !!! The following ORDER of the enum class holding the Version numbers SHOULD NOT BE ALTERED.
+	// New versions shold be ADDED to the end of this list 
+	enum class EmotiBitVersion {
+		V01B = 0,
+		V01C = 1,
+		V02B = 2,
+		V02F = 3,
+		V02H = 4,
+		V03B = 5
+	};
+
+	class EmotiBitPinMapping
+	{
+	public:
+		enum class EmotiBitPinName
+		{
+			EMOTIBIT_I2C_CLOCK,
+			EMOTIBTI_I2C_DATA,
+			HIBERNATE,
+			EMOTIBIT_BUTTON,
+			EDL,
+			EDR,
+			SD_CARD_CHIP_SELECT,
+			SPI_CLK,
+			SPI_MOSI,
+			SPI_MISO,
+			PPG_INT,
+			BMI_INT1,
+			BMI_INT2,
+			BMM_INT,
+			BATTERY_READ_PIN,
+			COUNT //cannot be more than 28 (16 + 12) 
+		};
+
+	private:
+		static const int _MAX_EMOTIBIT_PIN_COUNT = 28;
+		int _assignedPin[_MAX_EMOTIBIT_PIN_COUNT] = { 0 };
+		//const char *emotiBitPinNameString[28];
+
+	public:
+		/*
+		* At the time of initialization, assign all the pin numbers to the emotibit pin names
+		*/
+		bool initMapping(EmotiBitVersionController::EmotiBitVersion version);
+
+		int getAssignedPin(EmotiBitPinMapping::EmotiBitPinName pin);
+
+		void echoPinMapping();
+
+	}emotiBitPinMapping;
+
+	class EmotiBitConstantsMapping
+	{
+	public:
+		enum class MathConstants
+		{
+			VCC,
+			ADC_BITS,
+			ADC_MAX_VALUE,
+			EDR_AMPLIFICATION,
+			VREF1,
+			VREF2,
+			EDA_FEEDBACK_R,
+			EDA_CROSSOVER_FILTER_FREQ,
+			EDA_SERIES_RESISTOR,
+			COUNT // cannot be > than the _MAX_MATH_CONSTANT_COUNT
+		};
+
+		enum class SystemConstants
+		{
+			EMOTIBIT_HIBERNATE_LEVEL,
+			LED_DRIVER_CURRENT,
+			COUNT // cannot be greater than the _MAX_SYSTEM_CONSTANT_COUNT
+		};
+	private:
+		static const int _MAX_MATH_CONSTANT_COUNT = 10;
+		static const int _MAX_SYSTEM_CONSTANT_COUNT = 10;
+
+	private:
+		float _assignedMathConstants[_MAX_MATH_CONSTANT_COUNT] = { 0 };
+		int _assignedSystemConstants[_MAX_SYSTEM_CONSTANT_COUNT] = { 0 };
+		const int _INVALID_MATH_CONSTANT_FOR_VERSION = -1;
+		const int _INVALID_REQUEST = -2; // addresses out of bounds(for array indexing) request
+		bool _initAssignmentComplete = false;
+	private:
+		bool _initMappingMathConstants(EmotiBitVersionController::EmotiBitVersion version);
+		bool _initMappingSystemConstants(EmotiBitVersionController::EmotiBitVersion version);
+	public:
+		bool initMapping(EmotiBitVersionController::EmotiBitVersion version);
+		float getMathConstant(MathConstants constant);
+		int getSystemConstant(SystemConstants constant);
+		void echoConstants();
+		bool setMathConstantForTesting(MathConstants constant);
+		bool setSystemConstantForTesting(SystemConstants constant);
+	}emotiBitConstantsMapping;
+
+public:
+	const char* getHardwareVersion(EmotiBitVersion version);
+
+};
+#endif

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -90,7 +90,7 @@ public:
 	private:
 		float _assignedMathConstants[_MAX_MATH_CONSTANT_COUNT] = { 0 };
 		int _assignedSystemConstants[_MAX_SYSTEM_CONSTANT_COUNT] = { 0 };
-		const int _INVALID_MATH_CONSTANT_FOR_VERSION = -1;
+		const int _INVALID_CONSTANT_FOR_VERSION = -1;
 		const int _INVALID_REQUEST = -2; // addresses out of bounds(for array indexing) request
 		bool _initAssignmentComplete = false;
 	private:
@@ -106,7 +106,7 @@ public:
 	}emotiBitConstantsMapping;
 
 public:
-	const char* getHardwareVersion(EmotiBitVersion version);
+	static const char* getHardwareVersion(EmotiBitVersion version);
 
 };
 #endif

--- a/examples/EmotiBit_Example/EmotiBit_Example.ino
+++ b/examples/EmotiBit_Example/EmotiBit_Example.ino
@@ -33,7 +33,7 @@ void setup()
 	Serial.println("Serial started");
 	delay(2000);	// short delay to allow user to connect to serial, if desired
 
-	emotibit.setup(EmotiBit::Version::V02H);
+	emotibit.setup();
 
 	// Attach callback functions
 	emotibit.attachShortButtonPress(&onShortButtonPress);


### PR DESCRIPTION
## Description
- Adds `Autodetecting Emotibit Version` on startup. 
  - The emotibit class no longer needs a version input from the user in code.
  - Simply plug in Either version of emotibit(V2 or V3), and the feather can automatically detect and start working with the emotibit.

## Functionality
- The EmotiBit version is detected.
  - The `EDR` pin is measured for different `hibernate pin` states, and this test is used to evaluate the emotibit version.
  - `V2` activates EDR when the hibernate pin is LOW 
  - `V3` activates EDR when the hibernate is HIGH
  - Pin and constant assignments are stored in separate arrays `_assignedPin`, `_assignedMathConstant` and `_assignedSystemConstants`.
  - These arrays are indexed using the enum classes `PinNames`, `MathConstants` and `SystemConstants`
  - Using the getMapping function, the data stored in the array is shared with the variables in the EmotiBit class
- The EmotiBit version and feather version are used to perform pin and constant mapping
 
## Changes
- `EmotiBitVersionController` class
  - This class now holds all the version data about the emotibit feather pair.
  - Subclasses: `EmotiBitPinMapping` and `EmotiBitConstantMapping`
   - `EmotiBitVersion`
     - This enum class now holds all the emotibit versions. Whenever a new emotibit version is added, this enum MUST be updated.  
   - `EmotiBitPinMapping`
      - This class assigns a feather pin to every emotibit pin depending on the feather and emotibit version. check the `initMapping()` function for more details.
   - `EmotiBitConstantMapping` This class handles assignment of all the math and system constants in emotibit.
     - `EmotibitMathConstants`
     - `EmotiBitSystemConstants`