### PR TITLE
Moved EmotiBit version detection outside EmotiBit.cpp

### DIFF
--- a/AdcCorrection.h
+++ b/AdcCorrection.h
@@ -72,7 +72,7 @@ Bootup
 #include "wiring_private.h"
 
 // use the macro below to print different log messages on the serial when debugging
-//#define ADC_CORRECTION_VERBOSE
+#define ADC_CORRECTION_VERBOSE
 #define ATWINC_FLASH_4M_SZ (512 * 1024UL)
 
 typedef struct {

--- a/EdaCorrection.cpp
+++ b/EdaCorrection.cpp
@@ -636,7 +636,8 @@ int EdaCorrection::readEmotiBitVersion(Si7013* si7013)
 	{
 		// Sensor found
 		uint8_t emotibitVersion = 0;
-		emotibitVersion = (uint8_t)si7013->readRegister8(otpMemoryMap.emotiBitVersionAddr, true);
+		uint8_t emotiBitVersionAddr = 0xB7;
+		emotibitVersion = (uint8_t)si7013->readRegister8(emotiBitVersionAddr, true);
 		if (emotibitVersion == 255)
 		{
 			Serial.println("OTP has not yet been updated");
@@ -645,8 +646,8 @@ int EdaCorrection::readEmotiBitVersion(Si7013* si7013)
 		{
 			Serial.println("######################");
 			Serial.print("The EmotiBit Version read from OTP is: ");
-			Serial.println(EmotiBitVersionController::getHardwareVersion((EmotiBitVersionController::EmotiBitVersion)emotibitVersion));
-			//Serial.println(EmotiBitemotibitVersion);
+			//Serial.println(EmotiBitVersionController::getHardwareVersion((EmotiBitVersionController::EmotiBitVersion)emotibitVersion));
+			Serial.println(emotibitVersion);
 			Serial.println("######################");
 		}
 		return emotibitVersion;

--- a/EdaCorrection.cpp
+++ b/EdaCorrection.cpp
@@ -624,6 +624,8 @@ EdaCorrection::Status EdaCorrection::writeToOtp(Si7013* si7013)
 	}
 }
 
+// moved to EmotiBitVersionController class
+/*
 int EdaCorrection::readEmotiBitVersion(Si7013* si7013)
 {
 	if (checkSensorConnection(si7013) == false)
@@ -653,7 +655,7 @@ int EdaCorrection::readEmotiBitVersion(Si7013* si7013)
 		return emotibitVersion;
 	}
 }
-
+*/
 
 EdaCorrection::Status EdaCorrection::readFromOtp(Si7013* si7013, bool isOtpOperation)
 {

--- a/EdaCorrection.h
+++ b/EdaCorrection.h
@@ -1,3 +1,5 @@
+#ifndef _EDA_CORRECTION_H
+#define _EDA_CORRECTION_H
 /*
 This class has been designed to work asynchronously as writing to the SI-7013 chip can be performed only using I2c and
 emotibit only allows I2C communication during ISR.
@@ -51,7 +53,7 @@ NORMAL
 #include "Arduino.h"
 #include "Wire.h"
 #include "EmotiBit_Si7013.h"
-#include "EmotiBitVersionController.h"
+//#include "EmotiBitVersionController.h"
 //#define USE_ALT_SI7013
 #define ACCESS_MAIN_ADDRESS
 
@@ -222,7 +224,7 @@ public:
 	*/
 	bool getApprovalStatus();
 
-	bool checkSensorConnection(Si7013* si7013);
+	static bool checkSensorConnection(Si7013* si7013);
 
 	//EdaCorrection::Status writeEmotiBitVersionToOtp(Si7013 *si7013, int8_t version = -1);
 
@@ -237,7 +239,7 @@ public:
 	/*
 	Returns the emotiBit version read from the OTP
 	*/
-	int readEmotiBitVersion(Si7013* si7013);
+	static int readEmotiBitVersion(Si7013* si7013);
 
 	//uint8_t readFromOtp(TwoWire* emotibit_i2c, uint8_t addr);
 	/*
@@ -255,3 +257,5 @@ public:
 
 	void displayCorrections();
 };
+
+#endif

--- a/EdaCorrection.h
+++ b/EdaCorrection.h
@@ -53,8 +53,8 @@ NORMAL
 #include "Arduino.h"
 #include "Wire.h"
 #include "EmotiBit_Si7013.h"
-//#include "EmotiBitVersionController.h"
-//#define USE_ALT_SI7013
+#include "EmotiBitVersionController.h"
+
 #define ACCESS_MAIN_ADDRESS
 
 class EdaCorrection
@@ -74,7 +74,8 @@ public:
 		size_t edlAddresses[NUM_EDL_CORRECTION_VALUES] = { 0x82, 0x86, 0x8A, 0x8E, 0x92 };
 		size_t edrAddresses = 0xB0 ;
 		size_t edlTestAddress = 0xA0;
-		size_t emotiBitVersionAddr = 0xB7;
+		//size_t emotiBitVersionAddr = 0xB7;// moved to EmotiBitVersionController class
+		size_t emotiBitVersionAddr = EmotiBitVersionController::EMOTIBIT_VERSION_ADDR_SI7013_OTP;
 		size_t dataVersionAddr = 0xB6;
 		bool emotiBitVersionWritten = false;
 		bool dataVersionWritten = false;
@@ -224,7 +225,7 @@ public:
 	*/
 	bool getApprovalStatus();
 
-	static bool checkSensorConnection(Si7013* si7013);
+	bool checkSensorConnection(Si7013* si7013);
 
 	//EdaCorrection::Status writeEmotiBitVersionToOtp(Si7013 *si7013, int8_t version = -1);
 
@@ -239,7 +240,7 @@ public:
 	/*
 	Returns the emotiBit version read from the OTP
 	*/
-	static int readEmotiBitVersion(Si7013* si7013);
+	//static int readEmotiBitVersion(Si7013* si7013);
 
 	//uint8_t readFromOtp(TwoWire* emotibit_i2c, uint8_t addr);
 	/*

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -88,7 +88,7 @@ void EmotiBit::bmm150ReadTrimRegisters()
 	temp_msb = ((uint16_t)(trim_xy1xy2[5] & 0x7F)) << 8;
 	bmm150TrimData.dig_xyz1 = (uint16_t)(temp_msb | trim_xy1xy2[4]);
 }
-
+/*
 int EmotiBit::detectEmotiBitVersion()
 {
 	uint8_t versionEst = 0;
@@ -247,10 +247,11 @@ int EmotiBit::detectEmotiBitVersion()
 	}
 	
 }
-
+*/
 uint8_t EmotiBit::setup(size_t bufferCapacity)
 {
-	_version = (EmotiBitVersionController::EmotiBitVersion)detectEmotiBitVersion();
+	EmotiBitVersionController::EmotiBitVersionDetection detectVersion(_EmotiBit_i2c, &tempHumiditySensor, &SD, &_emotiBitWiFi);
+	_version = (EmotiBitVersionController::EmotiBitVersion)detectVersion.begin();
 	bool initResult = false;
 	// IMPORTANT. Need pin initialization for emotibit to work
 	// initializing the pin and constant mapping
@@ -925,6 +926,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	}
 } // Setup
 
+/*
 bool EmotiBit::setupSdCard(bool &isConfigFilePresent)
 {
 	Serial.print("\nInitializing SD card...");
@@ -971,6 +973,7 @@ bool EmotiBit::setupSdCard(bool &isConfigFilePresent)
 	return true;
 
 }
+*/
 
 bool EmotiBit::addPacket(uint32_t timestamp, EmotiBit::DataType t, float * data, size_t dataLen, uint8_t precision) {
 	static EmotiBitPacket::Header header;
@@ -2773,7 +2776,7 @@ void EmotiBit::hibernate() {
 	LowPower.deepSleep();
 }
 
-
+/*
 // Loads the configuration from a file
 bool EmotiBit::loadConfigFile(const String &filename) {
 	// Open file for reading
@@ -2828,7 +2831,7 @@ bool EmotiBit::loadConfigFile(const String &filename) {
 	file.close();
 	return true;
 }
-
+*/
 
 bool EmotiBit::writeSdCardMessage(const String & s) {
 	// Break up the message in to bite-size chunks to avoid over running the UDP or SD card write buffers

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -250,7 +250,12 @@ int EmotiBit::detectEmotiBitVersion()
 */
 uint8_t EmotiBit::setup(size_t bufferCapacity)
 {
-	EmotiBitVersionController::EmotiBitVersionDetection detectVersion(_EmotiBit_i2c, &tempHumiditySensor, &SD, &_emotiBitWiFi);
+	if (_EmotiBit_i2c != nullptr)
+	{
+		delete(_EmotiBit_i2c);
+	}
+	_EmotiBit_i2c = new TwoWire(&sercom1, 11, 13);
+	EmotiBitVersionController::EmotiBitVersionDetection detectVersion(_EmotiBit_i2c, &tempHumiditySensor, &SD, &_emotiBitWiFi, &chipBegun.SI7013);
 	_version = (EmotiBitVersionController::EmotiBitVersion)detectVersion.begin();
 	bool initResult = false;
 	// IMPORTANT. Need pin initialization for emotibit to work

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -474,9 +474,9 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	Serial.println("\nSensor setup:");
 	// Setup EDA
 	Serial.println("Configuring ADC Corrections...");
-	_edlPin = A0;
-	//pinMode(_edlPin, INPUT);
-	//pinMode(_edrPin, INPUT);
+	//_edlPin = A0;
+	pinMode(_edlPin, INPUT);
+	pinMode(_edrPin, INPUT);
 	samdStorageAdcValues = samdFlashStorage.read(); // reading from samd flash storage into local struct
 	if (!samdStorageAdcValues.valid)
 	{
@@ -1332,6 +1332,9 @@ int8_t EmotiBit::updateEDAData()
 		edlTemp = average(edlBuffer);
 		edrTemp = average(edrBuffer);
 
+		// Perform data conversion
+		edlTemp = edlTemp * _vcc / adcRes;	// Convert ADC to Volts
+		edrTemp = edrTemp * _vcc / adcRes;	// Convert ADC to Volts
 
 		pushData(EmotiBit::DataType::EDL, edlTemp, &edlBuffer.timestamp);
 		if (edlClipped) {
@@ -1342,9 +1345,6 @@ int8_t EmotiBit::updateEDAData()
 		if (edrClipped) {
 			pushData(EmotiBit::DataType::DATA_CLIPPING, (uint8_t)EmotiBit::DataType::EDR, &edrBuffer.timestamp);
 		}
-		// Perform data conversion
-		edlTemp = edlTemp * _vcc / adcRes;	// Convert ADC to Volts
-		edrTemp = edrTemp * _vcc / adcRes;	// Convert ADC to Volts
 
 
 		// EDL Digital Filter

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -37,7 +37,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.30";
+	String firmware_version = "1.2.31";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -351,7 +351,7 @@ public:
 	DataType _serialData = DataType::length;
 	volatile bool buttonPressed = false;
 
-	bool setupSdCard(bool &isConfigFilePresent);
+	//bool setupSdCard(bool &isConfigFilePresent);
 	void updateButtonPress();
 	void hibernate();
 	void startTimer(int frequencyHz);
@@ -367,7 +367,7 @@ public:
 	void setPowerMode(PowerMode mode);
 	bool writeSdCardMessage(const String &s);
 	int freeMemory();
-	bool loadConfigFile(const String &filename);
+	//bool loadConfigFile(const String &filename);
 	bool addPacket(uint32_t timestamp, EmotiBit::DataType t, float * data, size_t dataLen, uint8_t precision = 4);
 	bool addPacket(EmotiBit::DataType t);
 	void parseIncomingControlPackets(String &controlPackets, uint16_t &packetNumber);

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -37,7 +37,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.29";
+	String firmware_version = "1.2.29-t";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -37,7 +37,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.29-t";
+	String firmware_version = "1.2.30";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -1,13 +1,26 @@
-// the Emotibit Pin mapping class handles mapping of the Feather pin number to the EmotiBit pin name
+// the Emotibit Version Controller class handles all things related to EmotiBit Versions. This includes
+// 1. Detecting EmotiBit Version on startup
+// 2. Loading feather-emotibit pin mappings
+// 3. Loading emotibit specific constants
 // Author : Nitin
 // date: 17 Feb 2021
 
-#ifndef _EMOTIBIT_PIN_MAPPING_H
-#define _EMOTIBIT_PIN_MAPPING_H
+#ifndef _EMOTIBIT_VERSION_CONTROLLER_H
+#define _EMOTIBIT_VERSION_CONTROLLER_H
 
+#include <Arduino.h>
+#include <Wire.h>
+#include <SdFat.h>
+#include <EmotiBit_Si7013.h>
+#include "wiring_private.h"
+#include <ArduinoJson.h>
+#include "EmotiBitWiFi.h"
+#include "EdaCorrection.h"
 
 class EmotiBitVersionController
 {
+private:
+	const char *_configFilename = "config.txt";
 public:
 	// !!! The following ORDER of the enum class holding the Version numbers SHOULD NOT BE ALTERED.
 	// New versions shold be ADDED to the end of this list 
@@ -105,8 +118,35 @@ public:
 		bool setSystemConstantForTesting(SystemConstants constant);
 	}emotiBitConstantsMapping;
 
+	class EmotiBitVersionDetection
+	{
+	private:
+		int _versionEst;
+		int _otpEmotiBitVersion;
+		int _hibernatePin;
+		int _emotiBitI2cClkPin;
+		int _emotiBitI2cDataPin;
+		int _sdCardChipSelectPin;
+		const char *_configFileName = "config.txt";
+		bool _isConfigFilePresent;
+	private:
+		TwoWire *_EmotiBit_i2c;
+		Si7013 *_tempHumiditySensor;
+		SdFat *_SD;
+		EmotiBitWiFi *_emotiBitWiFi;
+		EmotiBitPinMapping *_emotiBitPinMapping;
+		EmotiBitConstantsMapping *_emotiBitConstantsMapping;
+		//EdaCorrection *_edaCorrection;
+
+	public:
+		EmotiBitVersionDetection(TwoWire* EmotiBit_I2c, Si7013 *tempHumiditySensor, SdFat *SD, EmotiBitWiFi *emotiBitWiFi);
+		int begin();
+		bool setupSdCard();
+		bool loadConfigFile();
+
+	};
+
 public:
 	static const char* getHardwareVersion(EmotiBitVersion version);
-
 };
 #endif

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -15,12 +15,18 @@
 #include "wiring_private.h"
 #include <ArduinoJson.h>
 #include "EmotiBitWiFi.h"
-#include "EdaCorrection.h"
+//#include "EdaCorrection.h"
+
+// Controls which sensor is used OTP access. uncomment the line below is use external SI-7013 connected to teh emotibit
+//#define USE_ALT_SI7013
 
 class EmotiBitVersionController
 {
 private:
 	const char *_configFilename = "config.txt";
+public:
+	// Important: changing this address will change where the EmotiBit version is stored on the OTP
+	static const uint8_t EMOTIBIT_VERSION_ADDR_SI7013_OTP = 0xB7;
 public:
 	// !!! The following ORDER of the enum class holding the Version numbers SHOULD NOT BE ALTERED.
 	// New versions shold be ADDED to the end of this list 
@@ -129,6 +135,7 @@ public:
 		int _sdCardChipSelectPin;
 		const char *_configFileName = "config.txt";
 		bool _isConfigFilePresent;
+		bool *_si7013ChipBegun;
 	private:
 		TwoWire *_EmotiBit_i2c;
 		Si7013 *_tempHumiditySensor;
@@ -139,10 +146,11 @@ public:
 		//EdaCorrection *_edaCorrection;
 
 	public:
-		EmotiBitVersionDetection(TwoWire* EmotiBit_I2c, Si7013 *tempHumiditySensor, SdFat *SD, EmotiBitWiFi *emotiBitWiFi);
+		EmotiBitVersionDetection(TwoWire* EmotiBit_I2c, Si7013 *tempHumiditySensor, SdFat *SD, EmotiBitWiFi *emotiBitWiFi, bool *si7013ChipBegun);
 		int begin();
 		bool setupSdCard();
 		bool loadConfigFile();
+		int readEmotiBitVersionFromSi7013(Si7013 *si7013);
 
 	};
 


### PR DESCRIPTION
## Description
- Created new class `EmotiBitVersionDetection` enclosed in class `EmotiBitVersionController`
  - This class handles detecting the version of the plugged emotibit to enable power up procedure and initiate I2c.
  - After the I2C has been initiated, the class reads the version stored on the Si-7013 OTP. If No version is found, the emotibit continues with the estimate of the version detected.

## Changes
- EmotiBit.cpp
  - The following functions have been pulled out
    - `detectEmotiBitVersion` - moved to class `EmotiBitVersionDetection`
    - `setupSdCard` - moved to class `EmotiBitVersionDetection`
    - `loadConfigFile`- moved to class `EmotiBitVersionDetection`
- EdaCorrection
  - `readEmotiBitVersion` has been moved to `EmotiBitVersionDetection`
