### PR TITLE
Adds an offset correction for Analog read called in the ISR sub routine

### DIFF
--- a/AdcCorrection.h
+++ b/AdcCorrection.h
@@ -72,7 +72,7 @@ Bootup
 #include "wiring_private.h"
 
 // use the macro below to print different log messages on the serial when debugging
-//#define ADC_CORRECTION_VERBOSE
+#define ADC_CORRECTION_VERBOSE
 #define ATWINC_FLASH_4M_SZ (512 * 1024UL)
 
 
@@ -81,6 +81,8 @@ class AdcCorrection
 private:
 	uint16_t _gainCorr; //drop these. the global variable has the values needed
 	uint16_t _offsetCorr; //drop these. the global variable has the values needed
+	uint16_t _measuredAdcInIsr = 0;
+	int8_t _isrOffsetCorr = 0;
 	bool _isAtwincDownloadMode = 0;
 	uint8_t  _atwincFlashSize;
 	bool _isupdatedAtwincArray = false;
@@ -99,11 +101,13 @@ public:
 		bool valid = false;
 		uint16_t _gainCorrection;
 		uint16_t _offsetCorrection;
+		int8_t _isrOffsetCorr = 0;
 	};
 
 	enum class DataFormatVersion
 	{
 		DATA_FORMAT_0 = 0,
+		DATA_FORMAT_1 = 1,
 		COUNT,
 		UNKNOWN
 	};
@@ -155,7 +159,7 @@ public:
 	@Constructor
 	@usage: Called from setup when the Correction values are not stored in the SAMD flash
 	*/
-	AdcCorrection(AdcCorrection::AdcCorrectionRigVersion version, uint16_t &gainCorr, uint16_t &offsetCorr, bool &valid);
+	AdcCorrection(AdcCorrection::AdcCorrectionRigVersion version, uint16_t &gainCorr, uint16_t &offsetCorr, bool &valid, int8_t &isrOffsetCorr);
 
 	/*
 	@usage: This function calls various other class functions to 
@@ -164,6 +168,8 @@ public:
 	3. Calculate Corretion data and pass it to the setup function in EmotiBit.cpp
 	*/
 	bool begin(uint16_t &gainCorr, uint16_t &offsetCorr, bool &valid);
+
+	bool updateIsrOffsetCorr();
 
 	/*
 	@usage:

--- a/EdaCorrection.h
+++ b/EdaCorrection.h
@@ -54,7 +54,7 @@ NORMAL
 #include "EmotiBit_Si7013.h"
 #include "EmotiBitVersionController.h"
 
-//#define ACCESS_MAIN_ADDRESS
+#define ACCESS_MAIN_ADDRESS
 
 class EdaCorrection
 {

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -150,9 +150,9 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 		fwVersionModifier = "-TC";
 		_debugMode = true;
 	}
-	else if (testingMode == TestingMode::PROGRAMMER)
+	else if (testingMode == TestingMode::ISR_CORRECTION_UPDATE)
 	{
-		fwVersionModifier = "-PM";
+		fwVersionModifier = "-ISR_CORR";
 		_debugMode = true;
 	}
 
@@ -264,12 +264,13 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 				delete edaCorrection;
 				edaCorrection = nullptr;
 			}
-			/*
 			else
 			{
-				acquireData.tempHumidity = false;
+				if (testingMode == TestingMode::ISR_CORRECTION_UPDATE)
+				{
+					testingMode = TestingMode::NONE;
+				}
 			}
-			*/
 		}
 		else if (input == 'O')
 		{
@@ -1286,7 +1287,7 @@ int8_t EmotiBit::updateEDAData()
 		edlTemp = average(edlBuffer);
 		edrTemp = average(edrBuffer);
 
-		if (testingMode == TestingMode::PROGRAMMER)
+		if (testingMode == TestingMode::ISR_CORRECTION_UPDATE)
 		{
 			// send raw EDL values
 			pushData(EmotiBit::DataType::EDL, edlTemp, &edlBuffer.timestamp);

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -35,12 +35,12 @@ public:
 		NONE,
 		CHRONIC,
 		ACUTE,
-		PROGRAMMER,
+		ISR_CORRECTION_UPDATE,
 		length
 	};
 
-	String firmware_version = "1.2.65";
-	TestingMode testingMode = TestingMode::PROGRAMMER;
+	String firmware_version = "1.2.67";
+	TestingMode testingMode = TestingMode::ISR_CORRECTION_UPDATE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 
 	bool _debugMode = false;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -35,11 +35,12 @@ public:
 		NONE,
 		CHRONIC,
 		ACUTE,
+		PROGRAMMER,
 		length
 	};
 
-	String firmware_version = "1.2.64";
-	TestingMode testingMode = TestingMode::NONE;
+	String firmware_version = "1.2.65";
+	TestingMode testingMode = TestingMode::PROGRAMMER;
 	const bool DIGITAL_WRITE_DEBUG = false;
 
 	bool _debugMode = false;
@@ -345,6 +346,7 @@ public:
 	float _edlDigFiltAlpha = 0;
 	float _edlDigFilteredVal = -1;
 	float _edaSeriesResistance = 0;
+	int8_t _isrOffsetCorr = 0;
 	DataType _serialData = DataType::length;
 	volatile bool buttonPressed = false;
 


### PR DESCRIPTION
## Description
- The Analog read function call returns values offset by a certain factor when called from within the ISR.
- The offset appears to be constant can be corrected after it has been measured.

## Changes
- `AdcCorrection class`
  - `updateIsrOffsetCorr` New function added to write the isr offset correction on to the at-winc flash
- `EmotiBit.cpp`
  - new provision in setup to add isr correction offset.
  - This provision works only if the adc correction has been initially applied
  - `updateEDA`
    - The recorded edl and edr value are now offset corrected before tx to the oscilloscope
- `EmotiBit.h `
  - new testing mode added `ISR_CORRECTION_UPDATE`. 
  - This new mode is required to send "raw adc values" of the edl and edr to the oscilloscope. 
  - when in Eda calibration mode, this mode is automatically disabled because we need EDL and EDR in Volts during EDA calibration
