### PR TITLE
Adds improvements to isr correction and the whole Feather correction workflow

### DIFF
--- a/AdcCorrection.h
+++ b/AdcCorrection.h
@@ -81,12 +81,16 @@ class AdcCorrection
 private:
 	uint16_t _gainCorr; //drop these. the global variable has the values needed
 	uint16_t _offsetCorr; //drop these. the global variable has the values needed
-	uint16_t _measuredAdcInIsr = 0;
-	int8_t _isrOffsetCorr = 0;
+	float _measuredAdcInIsr = 0;
+	//int8_t _isrOffsetCorr = 0;
 	bool _isAtwincDownloadMode = 0;
 	uint8_t  _atwincFlashSize;
 	bool _isupdatedAtwincArray = false;
 	bool _isupdatedAtwincMetadataArray = false;
+	union IsrOffsetCorr {
+		float inFloat;
+		char inBytes[4];
+	}_isrOffsetCorr;
 public:
 	
 	const size_t ATWINC_MEM_LOC_DUPLICATE_DATA = 448*1024;  // primary start address for storing the adc values
@@ -101,7 +105,7 @@ public:
 		bool valid = false;
 		uint16_t _gainCorrection;
 		uint16_t _offsetCorrection;
-		int8_t _isrOffsetCorr = 0;
+		float _isrOffsetCorr = 0;
 	};
 
 	enum class DataFormatVersion
@@ -159,7 +163,7 @@ public:
 	@Constructor
 	@usage: Called from setup when the Correction values are not stored in the SAMD flash
 	*/
-	AdcCorrection(AdcCorrection::AdcCorrectionRigVersion version, uint16_t &gainCorr, uint16_t &offsetCorr, bool &valid, int8_t &isrOffsetCorr);
+	AdcCorrection(AdcCorrection::AdcCorrectionRigVersion version, uint16_t &gainCorr, uint16_t &offsetCorr, bool &valid, float &isrOffsetCorr);
 
 	/*
 	@usage: This function calls various other class functions to 
@@ -185,6 +189,7 @@ public:
 	*/
 	AdcCorrection::Status updateAtwincDataArray();
 	
+	bool parseAtwincDataArray();
 	
 	/*
 	@f: writeAtwincFlash

--- a/AdcCorrection.h
+++ b/AdcCorrection.h
@@ -284,6 +284,8 @@ public:
 	*/
 	AdcCorrection::Status initWifiModule();
 
+	bool isAtWincMetadataUpdated();
+
 	/*
 	Cheack the data and metadate location in the SPI flash to make sure data is not corrupt
 	*/

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -618,7 +618,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 			//samdFlashStorage.write(samdStorageAdcValues);// Writing it to the SAMD flash storage
 			_isrOffsetCorr = adcCorrectionValues._isrOffsetCorr;
 			Serial.print("Gain Correction:"); Serial.print(adcCorrectionValues._gainCorrection); Serial.print("\toffset correction:"); Serial.println(adcCorrectionValues._offsetCorrection);
-			Serial.print("isr offset Corr: "); Serial.println(_isrOffsetCorr);
+			Serial.print("isr offset Corr: "); Serial.println(_isrOffsetCorr,6);
 			Serial.println("Enabling the ADC with the correction values");
 			analogReadCorrection(adcCorrectionValues._offsetCorrection, adcCorrectionValues._gainCorrection);
 		}

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -36,10 +36,11 @@ public:
 		CHRONIC,
 		ACUTE,
 		ISR_CORRECTION_UPDATE,
+		ISR_CORRECTION_TEST,
 		length
 	};
 
-	String firmware_version = "1.2.69";
+	String firmware_version = "1.2.71";
 	TestingMode testingMode = TestingMode::ISR_CORRECTION_UPDATE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -39,7 +39,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.68";
+	String firmware_version = "1.2.69";
 	TestingMode testingMode = TestingMode::ISR_CORRECTION_UPDATE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 
@@ -346,7 +346,7 @@ public:
 	float _edlDigFiltAlpha = 0;
 	float _edlDigFilteredVal = -1;
 	float _edaSeriesResistance = 0;
-	int8_t _isrOffsetCorr = 0;
+	float _isrOffsetCorr = 0;
 	DataType _serialData = DataType::length;
 	volatile bool buttonPressed = false;
 

--- a/testing/AdcCorrectionTesting/WiFi-ATWINC1500-FlashEraseExample/WiFi-ATWINC1500-FlashEraseExample.ino
+++ b/testing/AdcCorrectionTesting/WiFi-ATWINC1500-FlashEraseExample/WiFi-ATWINC1500-FlashEraseExample.ino
@@ -6,7 +6,8 @@
 #include <WiFi101.h>
 #include <spi_flash/include/spi_flash.h>
 #include <spi_flash/include/spi_flash_map.h>
-
+#include "AdcCorrection.h"
+/*
 #define ATWINC_MEM_LOC_PRIMARY_DATA (448*1024UL)
 #define ATWINC_MEM_LOC_DUPLICATE_DATA (480*1024UL)
 #define ATWINC_MEM_LOC_LAST_SECTOR_FIRST_BYTE (508 * 1024)
@@ -16,133 +17,56 @@
 #define FLASH_ERASE_LENGTH 1
 #define FLASH_READ_ENABLE 1
 #define FLASH_ERASE_ENABLE 1
-
+*/
 void setup() {
   // put your setup code here, to run once:
 	Serial.begin(115200);
-	while(!Serial.available());
+	const uint8_t readSize = 40;
+	uint8_t data[readSize];
+	while (!Serial.available())
+	{
+		Serial.println("Enter a character to continue");
+		delay(1000);
+	}
+	Serial.read();
 	Serial.println("This code will erase the primary location, secondary location and the last sector(metadata on the AT-WINC)");
-
-	uint8 au8FlashContent[FLASH_DATA_READ_LENGTH] = {0};
-	uint32  u32FlashTotalSize = 0;
-	uint32  u32FlashOffset = ATWINC_MEM_LOC_PRIMARY_DATA;
-	uint8_t ret;
+	while (!Serial.available())
+	{
+		Serial.println("Enter a character to continue");
+		delay(1000);
+	}
+	AdcCorrection adcCorrection;
 	// Initialize the WiFI module and put it in download mode. Flash access is enabled only when the module is in download mode
 	WiFi.setPins(8,7,4,2); // Need this for working with WiFi module on Adafruit feather
 	nm_bsp_init();
+	uint8_t ret;
+	uint8_t atwincFlashSize;
 	ret = m2m_wifi_download_mode();
 
 	if(M2M_SUCCESS != ret)
 	{
-	  printf("Unable to enter download mode\r\n");
+	  Serial.println("Unable to enter download mode\r\n");
 	}
 	else
 	{
-	  u32FlashTotalSize = spi_flash_get_size();
+		atwincFlashSize = spi_flash_get_size();
 	}
 	Serial.println("Entered download mode successfully");
-	Serial.print("The flash size is:"); Serial.println(u32FlashTotalSize);
-
-	int eraseIter = 0;
-	while (eraseIter < 3)
-	{
-		if (eraseIter == 0)
-			u32FlashOffset = ATWINC_MEM_LOC_PRIMARY_DATA;
-		else if (eraseIter == 1)
-		{
-			u32FlashOffset = ATWINC_MEM_LOC_DUPLICATE_DATA;
-		}
-		else if (eraseIter == 2)
-		{
-			u32FlashOffset = ATWINC_MEM_LOC_LAST_SECTOR_FIRST_BYTE;
-		}
-
-		if (eraseIter != 2)
-		{
-			ret = spi_flash_read(au8FlashContent, u32FlashOffset, FLASH_DATA_READ_LENGTH);
-			if (M2M_SUCCESS != ret)
-			{
-				printf("Unable to read SPI sector\r\n");
-				break;
-			}
-			else
-			{
-				Serial.print("the data stored in the flash "); Serial.print(" @memLoc "); Serial.println(u32FlashOffset);
-				for (int i = 0; i < FLASH_DATA_READ_LENGTH; i++)
-				{
-					Serial.print(i); Serial.print(":"); Serial.print(au8FlashContent[i]); Serial.print("\t");
-				}
-			}
-
-			Serial.println("\nErasing flash");
-			ret = spi_flash_erase(u32FlashOffset, FLASH_ERASE_LENGTH);
-			if (M2M_SUCCESS != ret)
-			{
-				Serial.print("Unable to erase SPI sector\r\n");
-				break;
-			}
-			Serial.print("the UPDATED data stored in the flash "); Serial.print(" @memLoc "); Serial.println(u32FlashOffset);
-			ret = spi_flash_read(au8FlashContent, u32FlashOffset, FLASH_DATA_READ_LENGTH);
-			if (M2M_SUCCESS != ret)
-			{
-				printf("Unable to read SPI sector\r\n");
-				break;
-			}
-			else
-			{
-				for (int i = 0; i < FLASH_DATA_READ_LENGTH; i++)
-				{
-					Serial.print(i); Serial.print(":"); Serial.print(au8FlashContent[i]); Serial.print("\t");
-				}
-			}
-			Serial.println("\n");
-		}
-		else // metadata
-		{
-			u32FlashOffset = ATWINC_MEM_LOC_LAST_SECTOR_FIRST_BYTE;
-			ret = spi_flash_read(au8FlashContent, ATWINC_MEM_LOC_METADATA, 3);
-			if (M2M_SUCCESS != ret)
-			{
-				printf("Unable to read SPI sector\r\n");
-				break;
-			}
-			else
-			{
-				Serial.print("the data stored in the flash "); Serial.print(" @memLoc "); Serial.println(ATWINC_MEM_LOC_METADATA);
-				for (int i = 0; i < 3; i++)
-				{
-					Serial.print(i); Serial.print(":"); Serial.print(au8FlashContent[i]); Serial.print("\t");
-				}
-			}
-
-			Serial.println("\nErasing flash");
-			ret = spi_flash_erase(u32FlashOffset, FLASH_ERASE_LENGTH);
-			if (M2M_SUCCESS != ret)
-			{
-				Serial.print("Unable to erase SPI sector\r\n");
-				break;
-			}
-			Serial.print("the UPDATED data stored in the flash "); Serial.print(" @memLoc "); Serial.println(ATWINC_MEM_LOC_METADATA);
-			ret = spi_flash_read(au8FlashContent, ATWINC_MEM_LOC_METADATA, 3);
-			if (M2M_SUCCESS != ret)
-			{
-				printf("Unable to read SPI sector\r\n");
-				break;
-			}
-			else
-			{
-				for (int i = 0; i < 3; i++)
-				{
-					Serial.print(i); Serial.print(":"); Serial.print(au8FlashContent[i]); Serial.print("\t");
-				}
-			}
-			Serial.println("\n");
-		}
-		eraseIter++;
-	}
-
-	Serial.println("Verify that all the memory locations printed above hold 255 after erasing.");
-	Serial.println("\nend of setup");
+	ret = spi_flash_erase(adcCorrection.ATWINC_MEM_LOC_PRIMARY_DATA, 12);
+	Serial.println("Done erasing primary sector");
+	ret = spi_flash_erase(adcCorrection.ATWINC_MEM_LOC_DUPLICATE_DATA, 12);
+	Serial.println("Done erasing secondary sector");
+	ret = spi_flash_erase(adcCorrection.ATWINC_MEM_LOC_LAST_SECTOR_FIRST_BYTE, 12);
+	Serial.println("Done erasing last sector");
+	Serial.print("The flash size is:"); Serial.println(atwincFlashSize);
+	Serial.println("Reading location to verify data was cleared");
+	Serial.println("Reading primary loc");
+	ret = adcCorrection.readAtwincFlash(adcCorrection.ATWINC_MEM_LOC_PRIMARY_DATA, readSize, data);
+	Serial.println("Reading secondary loc");
+	ret = adcCorrection.readAtwincFlash(adcCorrection.ATWINC_MEM_LOC_DUPLICATE_DATA, readSize, data);
+	Serial.println("Reading metadata loc");
+	ret = adcCorrection.readAtwincFlash(adcCorrection.ATWINC_MEM_LOC_LAST_SECTOR_FIRST_BYTE, readSize, data);
+	Serial.println("\nend of code");
 
 	while(1);
 


### PR DESCRIPTION
## changes
- added changes referenced in #133 
- Isr Offset correction now accepts "expected value" from user. in the 'O' sub routine

## New flow for correction
- Upload the code in `ISR_CORRECTION_UPDATE` mode
- Stack the Adc Correction rig
- perform the adc correction by pressing `A` in setup
- record the raw values in the oscilloscope (should be around 372)
-  enter the raw values in the spreadsheet.(under `ISR EDL measured values`)
  - measure 5 values
- Reset the feather and enter the `O` special mode
- enter the avg measured isr value and the expected value
  - ex: `381, 371`, where 381 is the measured isr value and 371 is the expected ISR value
- Continue normal bootup. check the values on the oscilloscope under EDL to verify if the correction is working. you should see values around 371-372
- reset feather. enter the `E` special mode. activate dummy mode for eda calibration. 
- Get the calibration values to follow the steps for eda calibration.
- in dummy mode, the emotibit will continue to operate, now using the calibration values. 
- Plug in the High precision resistor rig, and verify with the oscilloscope that the EDA correcponds to the Rskin sim resistor.