### PR TITLE
Feat version controller v4

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -108,7 +108,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	Serial.println("...setting PIO_SERCOM");
 	pinPeripheral(EmotiBitVersionController::EMOTIBIT_I2C_DAT_PIN, PIO_SERCOM);
 	pinPeripheral(EmotiBitVersionController::EMOTIBIT_I2C_CLK_PIN, PIO_SERCOM);
-	_version = emotiBitVersionController.detectEmotiBitVersion(_EmotiBit_i2c);
+	_version = emotiBitVersionController.detectEmotiBitVersion(_EmotiBit_i2c, deviceAddress.EEPROM_FLASH_34AA02);
 	// If version is unknown
 	if (_version == EmotiBitVersionController::EmotiBitVersion::UNKNOWN)
 	{
@@ -137,7 +137,6 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 		Serial.println("Download v0.6.0 for Alpha boards");
 		hibernate(false);
 	}
-
 	String fwVersionModifier = "";
 	if (testingMode == TestingMode::ACUTE)
 	{

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -75,6 +75,7 @@ public:
 	//};
 	struct DeviceAddress {
 		uint8_t MLX = 0x3A;
+		uint8_t EEPROM_FLASH_34AA02 = 0x50; // 7 bit address
 	};
 	struct BMM150TrimData {
 		int8_t dig_x1;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -37,7 +37,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.77";
+	String firmware_version = "1.2.78";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -3,15 +3,8 @@
 
 const char* EmotiBitVersionController::getHardwareVersion(EmotiBitVersion version)
 {
-	if (version == EmotiBitVersion::V02H) 
-	{
-		return "V02h";
-	}
-	else if (version == EmotiBitVersion::V03B)
-	{
-		return "V03b";
-	}
-	else if (version == EmotiBitVersion::V01B)
+
+	if (version == EmotiBitVersion::V01B)
 	{
 		return "V01b";
 	}
@@ -27,6 +20,18 @@ const char* EmotiBitVersionController::getHardwareVersion(EmotiBitVersion versio
 	{
 		return "V02f";
 	}
+	else if (version == EmotiBitVersion::V02H)
+	{
+		return "V02h";
+	}
+	else if (version == EmotiBitVersion::V03B)
+	{
+		return "V03b";
+	}
+	else if (version == EmotiBitVersion::V04A)
+	{
+		return "V04a";
+	}
 }
 
 bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiBitVersion version)
@@ -38,12 +43,16 @@ bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiB
 	_assignedPin[(int)EmotiBitPinName::SPI_MOSI] = 23;
 	_assignedPin[(int)EmotiBitPinName::SPI_MISO] = 22;
 
-	if (version == EmotiBitVersion::V02B || version == EmotiBitVersion::V02H || version == EmotiBitVersion::V03B)
+	if (version == EmotiBitVersion::V02B || version == EmotiBitVersion::V02H || version == EmotiBitVersion::V03B || version == EmotiBitVersion::V04A)
 	{
 		_assignedPin[(int)EmotiBitPinName::HIBERNATE] = 6;
 		_assignedPin[(int)EmotiBitPinName::EMOTIBIT_BUTTON] = 12;
-		_assignedPin[(int)EmotiBitPinName::EDL] = A4;
-		_assignedPin[(int)EmotiBitPinName::EDR] = A3;
+		// Dont assign EDR or EDL pins for V4
+		if (version != EmotiBitVersion::V04A)
+		{
+			_assignedPin[(int)EmotiBitPinName::EDL] = A4;
+			_assignedPin[(int)EmotiBitPinName::EDR] = A3;
+		}
 		_assignedPin[(int)EmotiBitPinName::SD_CARD_CHIP_SELECT] = 19;
 		_assignedPin[(int)EmotiBitPinName::EMOTIBIT_I2C_CLOCK] = 13;
 		_assignedPin[(int)EmotiBitPinName::EMOTIBTI_I2C_DATA] = 11;
@@ -148,7 +157,11 @@ bool EmotiBitVersionController::_initMappingMathConstants(EmotiBitVersionControl
 	_assignedMathConstants[(int)MathConstants::ADC_BITS] = 12;
 	_assignedMathConstants[(int)MathConstants::ADC_MAX_VALUE] = pow(2, _assignedMathConstants[(int)MathConstants::ADC_BITS]) - 1;;
 	
-	if (version == EmotiBitVersion::V02H || version == EmotiBitVersion::V03B)
+	if (version == EmotiBitVersion::V04A)
+	{
+		_assignedMathConstants[(int)MathConstants::EDA_CROSSOVER_FILTER_FREQ] = 1.f / (2.f * PI * 200000.f * 0.0000047f);
+	}
+	else if (version == EmotiBitVersion::V02H || version == EmotiBitVersion::V03B)
 	{
 		_assignedMathConstants[(int)MathConstants::EDR_AMPLIFICATION] = 100.f / 3.3f;
 		// The Vref1 value being used is the empirical mean of Vref1 measured in emotibits during testing.
@@ -179,7 +192,7 @@ bool EmotiBitVersionController::_initMappingSystemConstants(EmotiBitVersionContr
 		_assignedSystemConstants[(int)SystemConstants::LED_DRIVER_CURRENT] = 26;
 		_assignedSystemConstants[(int)SystemConstants::EMOTIBIT_HIBERNATE_PIN_MODE] = INPUT;
 	}
-	else if (version == EmotiBitVersion::V03B)
+	else if (version == EmotiBitVersion::V03B || version == EmotiBitVersion::V04A)
 	{
 		_assignedSystemConstants[(int)SystemConstants::EMOTIBIT_HIBERNATE_LEVEL] = LOW;
 		_assignedSystemConstants[(int)SystemConstants::LED_DRIVER_CURRENT] = 6;
@@ -264,14 +277,14 @@ bool EmotiBitVersionController::setSystemConstantForTesting(SystemConstants cons
 	//ToDo: write the function to assign test values to the constants 
 }
 
-EmotiBitVersionController::EmotiBitVersion EmotiBitVersionController::detectEmotiBitVersion(TwoWire* EmotiBit_i2c)
+EmotiBitVersionController::EmotiBitVersion EmotiBitVersionController::detectEmotiBitVersion(TwoWire* EmotiBit_i2c, uint8_t flashMemoryI2cAddress)
 {
 	_versionEst = EmotiBitVersion::UNKNOWN;
 	_otpEmotiBitVersion = -1;
 	// V02B, V02H and V03B all have pin 6 as hibernate, and this code supports only those versions
 	pinMode(HIBERNATE_PIN, OUTPUT);
 	bool status;
-	Serial.println("****************************** DETECTING EMOTIBIT VERSION ************************************");
+	Serial.println("--------------------------- DETECTING EMOTIBIT VERSION --------------------------");
 	Serial.println("Making hibernate LOW");
 	digitalWrite(HIBERNATE_PIN, LOW);
 	// Try Setting up SD Card
@@ -292,6 +305,18 @@ EmotiBitVersionController::EmotiBitVersion EmotiBitVersionController::detectEmot
 		if (status)
 		{
 			_versionEst = EmotiBitVersion::V03B;
+			// check if flash module is present on the I2c line. This confirms EmotiBit V4+
+			if (flashMemoryI2cAddress != 255)
+			{
+				EmotiBit_i2c->beginTransmission(flashMemoryI2cAddress);
+				if (EmotiBit_i2c->endTransmission() == 0) // flash module detected
+				{
+					_versionEst = EmotiBitVersion::V04A;
+					// ToDo: in the future, we will also be reading the flash to get the EmotiBit version stored there
+					versionDetectionComplete = true;
+					return _versionEst;
+				}
+			}
 		}
 		else
 		{
@@ -356,7 +381,7 @@ EmotiBitVersionController::EmotiBitVersion EmotiBitVersionController::detectEmot
 	{
 		Serial.println("OTP has not yet been updated");
 		Serial.print("using the Estimated emotibit version detected from power up sequence: "); Serial.println(getHardwareVersion((EmotiBitVersion)_versionEst));
-		Serial.println("************************** END DETECTING EMOTIBIT VERSION ************************************");
+		Serial.println("-------------------------- END DETECTING EMOTIBIT VERSION --------------------------------");
 		versionDetectionComplete = true;
 		return _versionEst;
 	}
@@ -369,7 +394,7 @@ EmotiBitVersionController::EmotiBitVersion EmotiBitVersionController::detectEmot
 			Serial.println(getHardwareVersion((EmotiBitVersion)_otpEmotiBitVersion));
 			//Serial.println(emotibitVersion);
 			Serial.println("######################");
-			Serial.println("************************** END DETECTING EMOTIBIT VERSION ************************************");
+			Serial.println("-------------------------- END DETECTING EMOTIBIT VERSION --------------------------------");
 			versionDetectionComplete = true;
 			return (EmotiBitVersionController::EmotiBitVersion)_otpEmotiBitVersion;
 		}

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -138,7 +138,6 @@ public:
 	// member functions to perform version detection
 public:
 	EmotiBitVersion detectEmotiBitVersion(TwoWire* EmotiBit_i2c, uint8_t flashMemoryI2cAddress = 255);
-	bool detectSdCard();
 	int readEmotiBitVersionFromSi7013();
 
 public:

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -65,7 +65,7 @@ class EmotiBitVersionController
 
 public:
 	// !!! The following ORDER of the enum class holding the Version numbers SHOULD NOT BE ALTERED.
-	// New versions shold be ADDED to the end of this list 
+	// New versions should be ADDED to the end of this list 
 	enum class EmotiBitVersion {
 		UNKNOWN = -1,
 		V01B = 0,
@@ -73,7 +73,8 @@ public:
 		V02B = 2,
 		V02F = 3,
 		V02H = 4,
-		V03B = 5
+		V03B = 5,
+		V04A = 6
 	};
 	// For detecting EmotiBit Version
 public:
@@ -136,7 +137,7 @@ public:
 
 	// member functions to perform version detection
 public:
-	EmotiBitVersion detectEmotiBitVersion(TwoWire* EmotiBit_i2c);
+	EmotiBitVersion detectEmotiBitVersion(TwoWire* EmotiBit_i2c, uint8_t flashMemoryI2cAddress = 255);
 	bool detectSdCard();
 	int readEmotiBitVersionFromSi7013();
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit FeatherWing
-version=1.2.77
+version=1.2.78
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A library written for EmotiBit FeatherWing that supports all sensors included on the wing.


### PR DESCRIPTION
## Description
- Adds support to be able to detect V4 EmotiBits
  - V4 is detected by sending an ACK on the i2c line for the flash EEPROM
- The version detection has been changed from using the SD-Card to reading the Hibernate pin voltage on startup
 - For V2, hibernate is pulled HIGH
 - for V3 and V3+, hibernate is pulled LOW(internally by the LP5912 IC
 - To differentiate between V3 and V3+, we query the presence of EEPROM.  