### PR TITLE
Added changes to support version and sku verification from barcode

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -92,7 +92,7 @@ void EmotiBit::bmm150ReadTrimRegisters()
 uint8_t EmotiBit::setup(size_t bufferCapacity)
 {
 	uint32_t now = millis();
-	String barcode;
+	Barcode barcode;
 	while (!Serial.available() && millis() - now < 2000)
 	{
 	}
@@ -113,10 +113,12 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 				input = Serial.read();
 				if (input == '*')
 				{
-					barcode = Serial.readStringUntil('*');
+					barcode.code = Serial.readStringUntil('*');
 					barcodeReceived = true;
 				}
 			}
+			// parse the barcode
+			EmotiBitFactoryTest::parseBarcode(&barcode);
 			while (Serial.available())
 			{
 				Serial.read();
@@ -176,7 +178,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	if (testingMode == TestingMode::FACTORY_TEST)
 	{
 		// Pass only if FW version estimate is exactly = barcode version
-		if ((int)_version == EmotiBitFactoryTest::getVersionFromBarcode(barcode))// extract version from barcode
+		if ((int)_version == barcode.emotibitVersion)// extract version from barcode
 		{
 			EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::VERSION_VALIDATION, EmotiBitFactoryTest::TypeTag::TEST_PASS);
 		}
@@ -220,7 +222,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	{
 		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::FIRMWARE_VERSION, firmware_version.c_str());
 		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::EMOTIBIT_VERSION, EmotiBitVersionController::getHardwareVersion(_version));
-		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::EMOTIBIT_NUMBER, barcode.c_str());
+		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::EMOTIBIT_NUMBER, barcode.code.c_str());
 	}
 	//Serial.println("All Serial inputs must be used with **No Line Ending** option from the serial monitor");
 
@@ -699,7 +701,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	if (testingMode == TestingMode::FACTORY_TEST)
 	{
 		// compare estimate SKU with barcode SKU
-		if (EmotiBitFactoryTest::getSkuFromBarcode(barcode).equals(EmotiBitVersionController::getEmotiBitSku(emotiBitVersionController.emotibitSku)))
+		if (barcode.sku.equals(EmotiBitVersionController::getEmotiBitSku(emotiBitVersionController.emotibitSku)))
 		{
 			Serial.println("SKU is a match");
 			EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::SKU_VALIDATION, EmotiBitFactoryTest::TypeTag::TEST_PASS);

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -100,12 +100,18 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	{
 		char input;
 		input = Serial.read();
-		if (input == 'F')
+		if (input == EmotiBitFactoryTest::INIT_FACTORY_TEST)
 		{
 			testingMode = TestingMode::FACTORY_TEST;
-			Serial.println("Entered FACTORY TEST MODE");
+			String ackString;
+			ackString += EmotiBitFactoryTest::MSG_START_CHAR;
+			EmotiBitFactoryTest::updateOutputString(ackString, EmotiBitFactoryTest::TypeTag::FIRMWARE_VERSION, firmware_version.c_str());
+			ackString = ackString.substring(0, ackString.length() - 1);
+			ackString += EmotiBitFactoryTest::MSG_TERM_CHAR;
+			Serial.print(ackString);
+			
+			Serial.println("\nEntered FACTORY TEST MODE");
 			// send ACK to the computer
-			Serial.print("A");
 			bool barcodeReceived = false;
 			while (Serial.available() || !barcodeReceived)
 			{

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -126,7 +126,9 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 		}
 	}
 	EmotiBitVersionController emotiBitVersionController;
-	char factoryTestSerialOutput[150] = "***";
+	String factoryTestSerialOutput;
+	factoryTestSerialOutput.reserve(150);
+	factoryTestSerialOutput += EmotiBitFactoryTest::MSG_START_CHAR;
 	bool status = true;
 	if (_EmotiBit_i2c != nullptr)
 	{

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -182,7 +182,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	if (testingMode == TestingMode::FACTORY_TEST)
 	{
 		// Pass only if FW version estimate is exactly = barcode version
-		if ((int)_version == barcode.emotibitVersion)// extract version from barcode
+		if(EmotiBitFactoryTest::validateVersionEstimate(barcode.emotibitVersion, String(EmotiBitVersionController::getHardwareVersion(_version))))
 		{
 			EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::VERSION_VALIDATION, EmotiBitFactoryTest::TypeTag::TEST_PASS);
 		}
@@ -226,7 +226,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	{
 		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::FIRMWARE_VERSION, firmware_version.c_str());
 		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::EMOTIBIT_VERSION, EmotiBitVersionController::getHardwareVersion(_version));
-		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::EMOTIBIT_NUMBER, barcode.code.c_str());
+		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::EMOTIBIT_NUMBER, barcode.emotibitNumber.c_str());
 	}
 	//Serial.println("All Serial inputs must be used with **No Line Ending** option from the serial monitor");
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -39,7 +39,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.81";
+	String firmware_version = "1.2.82";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -40,7 +40,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.83";
+	String firmware_version = "1.2.84";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -39,7 +39,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.79";
+	String firmware_version = "1.2.80";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -40,7 +40,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.84";
+	String firmware_version = "1.2.86";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -24,6 +24,7 @@
 #include "DigitalFilter.h"
 #include "EmotiBitFactoryTest.h"
 #include "EmotiBitEda.h"
+#include "EmotiBitVariants.h"
 
 class EmotiBit {
   
@@ -39,7 +40,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.82";
+	String firmware_version = "1.2.83";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -39,7 +39,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.80";
+	String firmware_version = "1.2.81";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -423,48 +423,11 @@ int EmotiBitVersionController::readEmotiBitVersionFromSi7013()
 	return emotibitVersion;
 }
 
-// returns the version from barcode string "SKU-VERSION-NUMBER"
-int EmotiBitVersionController::getVersionFromBarcode(const char* barcode)
-{
-	char* temp;
-	char bcode[12];
-	strcpy(bcode, barcode);
-	char* version;
-	temp = strtok(bcode, "-"); // returns the sku
-	version = strtok(NULL, "-"); // return the version
-	// if barcode has V4
-	if (strcmp(version, "V4") == 0)
-	{
-		return (int)EmotiBitVersionController::EmotiBitVersion::V04A;
-	}
-	// if barcode has V3
-	else if (strcmp(version, "V3") == 0)
-	{
-		return (int)EmotiBitVersionController::EmotiBitVersion::V03B;
-	}
-	else
-	{
-		return 0;
-	}
-}
-
 // returns the SKU as a char array
 const char* EmotiBitVersionController::getEmotiBitSku(EmotiBitSku sku)
 {
 	if (sku == EmotiBitSku::EM)
-		return "EM";
+		return "EM\0";
 	else if (sku == EmotiBitSku::MD)
-		return "MD";
-}
-
-// returns the sku from barcode string "SKU-VERSION-NUMBER"
-char* EmotiBitVersionController::getSkuFromBarcode(const char* barcode)
-{
-	char bcode[12];
-	strcpy(bcode, barcode);
-	char* sku;
-	sku = strtok(bcode, "-");
-	Serial.print("The Sku extracted from barcode is:");
-	Serial.println(sku);
-	return sku;
+		return "MD\0";
 }

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -422,12 +422,3 @@ int EmotiBitVersionController::readEmotiBitVersionFromSi7013()
 	emotibitVersion = (uint8_t)_tempHumiditySensor.readRegister8(EMOTIBIT_VERSION_ADDR_SI7013_OTP, true);
 	return emotibitVersion;
 }
-
-// returns the SKU as a char array
-const char* EmotiBitVersionController::getEmotiBitSku(EmotiBitSku sku)
-{
-	if (sku == EmotiBitSku::EM)
-		return "EM\0";
-	else if (sku == EmotiBitSku::MD)
-		return "MD\0";
-}

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -6,31 +6,31 @@ const char* EmotiBitVersionController::getHardwareVersion(EmotiBitVersion versio
 
 	if (version == EmotiBitVersion::V01B)
 	{
-		return "V01b";
+		return "V01b\0";
 	}
 	else if (version == EmotiBitVersion::V01C)
 	{
-		return "V01c";
+		return "V01c\0";
 	}
 	else if (version == EmotiBitVersion::V02B)
 	{
-		return "V02b";
+		return "V02b\0";
 	}
 	else if (version == EmotiBitVersion::V02F)
 	{
-		return "V02f";
+		return "V02f\0";
 	}
 	else if (version == EmotiBitVersion::V02H)
 	{
-		return "V02h";
+		return "V02h\0";
 	}
 	else if (version == EmotiBitVersion::V03B)
 	{
-		return "V03b";
+		return "V03b\0";
 	}
 	else if (version == EmotiBitVersion::V04A)
 	{
-		return "V04a";
+		return "V04a\0";
 	}
 }
 

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -422,3 +422,49 @@ int EmotiBitVersionController::readEmotiBitVersionFromSi7013()
 	emotibitVersion = (uint8_t)_tempHumiditySensor.readRegister8(EMOTIBIT_VERSION_ADDR_SI7013_OTP, true);
 	return emotibitVersion;
 }
+
+// returns the version from barcode string "SKU-VERSION-NUMBER"
+int EmotiBitVersionController::getVersionFromBarcode(const char* barcode)
+{
+	char* temp;
+	char bcode[12];
+	strcpy(bcode, barcode);
+	char* version;
+	temp = strtok(bcode, "-"); // returns the sku
+	version = strtok(NULL, "-"); // return the version
+	// if barcode has V4
+	if (strcmp(version, "V4") == 0)
+	{
+		return (int)EmotiBitVersionController::EmotiBitVersion::V04A;
+	}
+	// if barcode has V3
+	else if (strcmp(version, "V3") == 0)
+	{
+		return (int)EmotiBitVersionController::EmotiBitVersion::V03B;
+	}
+	else
+	{
+		return 0;
+	}
+}
+
+// returns the SKU as a char array
+const char* EmotiBitVersionController::getEmotiBitSku(EmotiBitSku sku)
+{
+	if (sku == EmotiBitSku::EM)
+		return "EM";
+	else if (sku == EmotiBitSku::MD)
+		return "MD";
+}
+
+// returns the sku from barcode string "SKU-VERSION-NUMBER"
+char* EmotiBitVersionController::getSkuFromBarcode(const char* barcode)
+{
+	char bcode[12];
+	strcpy(bcode, barcode);
+	char* sku;
+	sku = strtok(bcode, "-");
+	Serial.print("The Sku extracted from barcode is:");
+	Serial.println(sku);
+	return sku;
+}

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -77,6 +77,13 @@ public:
 		V04A = 6
 	};
 	// For detecting EmotiBit Version
+
+	enum class EmotiBitSku {
+		INVALID = -1,
+		EM = 0,
+		MD = 1,
+		length
+	}emotibitSku;
 public:
 #if defined(ADAFRUIT_FEATHER_M0) 
 	static const int HIBERNATE_PIN = 6;
@@ -142,5 +149,8 @@ public:
 
 public:
 	static const char* getHardwareVersion(EmotiBitVersion version);
+	static const char* getEmotiBitSku(EmotiBitSku sku);
+	static int getVersionFromBarcode(const char* barcode);
+	static char* getSkuFromBarcode(const char* barcode);
 };
 #endif

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -150,7 +150,5 @@ public:
 public:
 	static const char* getHardwareVersion(EmotiBitVersion version);
 	static const char* getEmotiBitSku(EmotiBitSku sku);
-	static int getVersionFromBarcode(const char* barcode);
-	static char* getSkuFromBarcode(const char* barcode);
 };
 #endif

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -76,14 +76,7 @@ public:
 		V03B = 5,
 		V04A = 6
 	};
-	// For detecting EmotiBit Version
 
-	enum class EmotiBitSku {
-		INVALID = -1,
-		EM = 0,
-		MD = 1,
-		length
-	}emotibitSku;
 public:
 #if defined(ADAFRUIT_FEATHER_M0) 
 	static const int HIBERNATE_PIN = 6;
@@ -149,6 +142,5 @@ public:
 
 public:
 	static const char* getHardwareVersion(EmotiBitVersion version);
-	static const char* getEmotiBitSku(EmotiBitSku sku);
 };
 #endif


### PR DESCRIPTION
## Description
- Adds support to cross validate the Version and SKU from the barcode.
- Uses a new container `Barcode` to store barcode details in the setup.
- Changed the Setup output string to use MESSAGE_START and MESSAGE_TERM characters.
- No longer compatible with factory test SW 1.1.4 or lower

## Requirements
- Needs https://github.com/EmotiBit/EmotiBit_XPlat_Utils/pull/9

## Compatibility
- If using the Factory test SW, Needs the latest https://github.com/connectedfuturelabs/EmotiBit_Factory_Test/pull/19 

## Test
- example barcodes: `MD-V3-123456`, `MD-V4-123456`
- Tested inputs
  - ![image](https://user-images.githubusercontent.com/31810812/134415690-c6dc2500-937a-4a80-866c-ea09fbf89192.png)
  - ![image](https://user-images.githubusercontent.com/31810812/134415895-3b001300-f5a7-4370-9ef8-41f766cb57ef.png)
