### PR TITLE
Fix Hibernate in setup in Factory Test mode

### DIFF
--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -40,7 +40,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.2.86";
+	String firmware_version = "1.2.87";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 


### PR DESCRIPTION
## Description
- The EmotiBit now does not hibernate if any IC is detected as a FAIL in setup. Instead, it continues to complete setup and send the Factory Test report over serial.