### PR TITLE
Serial data can be toggled on/off for each DataType

### DIFF
--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -338,6 +338,7 @@ public:
 	bool _newDataAvailable[(uint8_t)EmotiBit::DataType::length];
 	uint8_t _printLen[(uint8_t)EmotiBit::DataType::length];
 	bool _sendData[(uint8_t)EmotiBit::DataType::length];
+	bool _sendSerialData[(uint8_t)EmotiBit::DataType::length];
 
 	SdFat SD;
 	volatile uint8_t battLevel = 100;


### PR DESCRIPTION
# Requires:
- https://github.com/EmotiBit/EmotiBit_XPlat_Utils/pull/12

# Usage:
In FACTORY_TEST_MODE
- sending to EmotiBit `@S+,EL~` over serial toggles EL data to be sent over serial
- `@S-,EL~` stops serial sending 

# Notes
- Someday we may want to refactor to centralize Serial.read() so that messages will work in FACTORY_TEST_MODE and normal mode. Right now it's a bit hard to have serial messages processed in multiple modes.