### PR TITLE
barcode is now received in std msg format

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -125,10 +125,19 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 			{
 				char input;
 				input = Serial.read();
-				if (input == '*')
+				if (input == EmotiBitFactoryTest::MSG_START_CHAR)
 				{
-					barcode.rawCode = Serial.readStringUntil('*');
-					barcodeReceived = true;
+					String msg = Serial.readStringUntil(EmotiBitFactoryTest::MSG_TERM_CHAR);
+					String msgTypeTag = msg.substring(0, 2);
+					if (msgTypeTag.equals(EmotiBitFactoryTest::TypeTag::EMOTIBIT_BARCODE))
+					{
+						EmotiBitPacket::getPacketElement(msg, barcode.rawCode, 3);
+						barcodeReceived = true;
+					}
+					else
+					{
+						Serial.println("Barcode not received in the correct packet format.");
+					}
 				}
 				if (millis() - waitStarForBarcode > 3000)
 					break;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -43,7 +43,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.2";
+	String firmware_version = "1.3.3";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;


### PR DESCRIPTION
# Description
- Barcode sent from testing software is now sent in a standard msg format.

# Requirements
- https://github.com/EmotiBit/EmotiBit_XPlat_Utils - v1.3.3+

