### PR TITLE
in Factory test mode, LED operate at the hihest PWM level

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -467,9 +467,18 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 		{
 			led.setCurrent(_emotiBitSystemConstants[(int)SystemConstants::LED_DRIVER_CURRENT]);
 		}
-		led.setLEDpwm((uint8_t)Led::RED, 8);
-		led.setLEDpwm((uint8_t)Led::BLUE, 8);
-		led.setLEDpwm((uint8_t)Led::YELLOW, 8);
+		if (testingMode == TestingMode::FACTORY_TEST)
+		{
+			led.setLEDpwm((uint8_t)Led::RED, 31);
+			led.setLEDpwm((uint8_t)Led::BLUE, 31);
+			led.setLEDpwm((uint8_t)Led::YELLOW, 31);
+		}
+		else
+		{
+			led.setLEDpwm((uint8_t)Led::RED, 8);
+			led.setLEDpwm((uint8_t)Led::BLUE, 8);
+			led.setLEDpwm((uint8_t)Led::YELLOW, 8);
+		}
 		led.setLED(uint8_t(EmotiBit::Led::RED), false);
 		led.setLED(uint8_t(EmotiBit::Led::BLUE), false);
 		led.setLED(uint8_t(EmotiBit::Led::YELLOW), false);

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -43,7 +43,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.3";
+	String firmware_version = "1.3.4";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;


### PR DESCRIPTION
# Description
- EmotiBit LEDs set to the highest PWN level in Factory Test Mode
- This should help with current measurements with testing

# Considerations
- Test Jig - R1 - [`RNCP1206FTD1R00`](https://www.digikey.com/en/products/detail/stackpole-electronics-inc/RNCP1206FTD1R00/2240302)
  - The power rating is 0.5W. EmotiBit at peak power consumption draw < 0.5A, so we are in spec
- EmotiBit - R1,R25,R26,R27 - [`CRCW04020000Z0EDHP`](https://www.digikey.com/product-detail/en/vishay-dale/CRCW04020000Z0EDHP/541-0.0YBCT-ND/2223008)
  - The power rating is 0.2W. **@3v3** volts, we can at max draw **60mA** on the digital side.

|State| max PWM(31/31) Current Draw(mA)|std PWM(8/31) current draw(mA)| 
|-----|----------------|-|
|WiFi Off| 37.8|38.1| 
|Blue ON|45.7|45.7| 
|Red ON|45.8|46.5| 
|Yellow ON|45.8|46.5| 
|R,B,Y ON| **62mA**|57.2| 