### PR TITLE
Feat HR and EDR metrics

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -1072,6 +1072,7 @@ bool EmotiBit::setupSdCard()
 
 bool EmotiBit::addPacket(uint32_t timestamp, const String typeTag, float * data, size_t dataLen, uint8_t precision, bool printToSerial)
 {
+	static EmotiBitPacket::Header header;
 	if (dataLen > 0) 
 	{
 		uint8_t protocolVersion = 1;
@@ -1083,7 +1084,7 @@ bool EmotiBit::addPacket(uint32_t timestamp, const String typeTag, float * data,
 			}
 		}
 		// Add packet header to _outDataPackets
-		static EmotiBitPacket::Header header;
+		
 		// create packet header and add to outputDataPackets
 		header = EmotiBitPacket::createHeader(typeTag, timestamp, _outDataPacketCounter++, dataLen, protocolVersion);
 		String headerString = EmotiBitPacket::headerToString(header);

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -1114,7 +1114,7 @@ bool EmotiBit::addPacket(uint32_t timestamp, const String typeTag, float * data,
 {
 	uint8_t protocolVersion = 1;
 	// toggle to True to serial print data to debug
-	bool printToSerial = true;
+	bool printToSerial = false;
 	// Add packet header to _outDataPackets
 	addPacketHeader(timestamp, typeTag, dataLen, protocolVersion, printToSerial);
 	// Add packet data to _outDataPackets

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -2644,6 +2644,57 @@ bool EmotiBit::printConfigInfo(File &file, const String &datetimeString) {
 		}
 	}
 
+	file.print(","); // Doing some manual printing to chunk JSON and save RAM
+	// Heart Rate
+	{
+		// Parse the root object
+		StaticJsonBuffer<bufferSize> jsonBuffer;
+		JsonObject &root = jsonBuffer.createObject();
+		const uint8_t nInfo = 1;
+		JsonObject* infos[nInfo];
+		JsonArray* typeTags[nInfo];
+		JsonObject* setups[nInfo];
+		uint8_t i = 0;
+		infos[i] = &(root.createNestedObject("info"));
+		infos[i]->set("name", "HeartRate");
+		infos[i]->set("type", "PPG");
+		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
+		typeTags[i]->add(EmotiBitPacket::TypeTag::HEART_RATE);
+		infos[i]->set("channel_count", 1);
+		infos[i]->set("channel_format", "int");
+		infos[i]->set("units", "bpm");
+		if (root.printTo(file) == 0) {
+#ifdef DEBUG
+			Serial.println(F("Failed to write to file"));
+#endif
+		}
+	}
+
+	file.print(","); // Doing some manual printing to chunk JSON and save RAM
+	// interBeat interval
+	{
+		// Parse the root object
+		StaticJsonBuffer<bufferSize> jsonBuffer;
+		JsonObject &root = jsonBuffer.createObject();
+		const uint8_t nInfo = 1;
+		JsonObject* infos[nInfo];
+		JsonArray* typeTags[nInfo];
+		JsonObject* setups[nInfo];
+		uint8_t i = 0;
+		infos[i] = &(root.createNestedObject("info"));
+		infos[i]->set("name", "InterBeatInterval");
+		infos[i]->set("type", "PPG");
+		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
+		typeTags[i]->add(EmotiBitPacket::TypeTag::INTER_BEAT_INTERVAL);
+		infos[i]->set("channel_count", 1);
+		infos[i]->set("channel_format", "float");
+		infos[i]->set("units", "mS");
+		if (root.printTo(file) == 0) {
+#ifdef DEBUG
+			Serial.println(F("Failed to write to file"));
+#endif
+		}
+	}
 	file.print("]"); // Doing some manual printing to chunk JSON and save RAM
 
 	return true;

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -2900,7 +2900,7 @@ void EmotiBit::processHeartRate()
 	const static float timePeriod = (1 / _samplingRates.ppg) * 1000; // in mS
 	float interBeatInterval; // in mS
 	float heartRate; // in bpm
-	static const int hrAlgoDcOffset = 100000; // randomly chosen to add offset to filtered ppgData. Required for HR algo to work
+	static const int hrAlgoDcOffset = 100000; // randomly chosen to add offset to filtered ppgData. HR algo needs a DC offset to work
 	dataSize = dataDoubleBuffers[basisSignal]->getData(&data, &timestamp, false);
 	if (dataSize)
 	{
@@ -2910,7 +2910,7 @@ void EmotiBit::processHeartRate()
 			float filteredPpg = ppgSensorHighpass.filter(data[i]);
 			interBeatSampleCount++;
 			// the heart rate algorithm can be found in: EmotiBit_MAX30101/src/heartRate.cpp
-			// Note: the algorithms also has its own FIR
+			// Note: the algorithm also has its own FIR
 			if (checkForBeat(filteredPpg + hrAlgoDcOffset))
 			{
 				// beat detected

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -411,12 +411,8 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 		Serial.print("buttonPin = "); Serial.println(buttonPin);
 		Serial.print("_batteryReadPin = "); Serial.println(_batteryReadPin);
 		Serial.print("Hibernate Pin = "); Serial.println(EmotiBitVersionController::HIBERNATE_PIN);
-		//Serial.print("_edlPin = "); Serial.println(_edlPin);
-		//Serial.print("_edrPin = "); Serial.println(_edrPin);
 		Serial.print("_vcc = "); Serial.println(_vcc);
 		Serial.print("adcRes = "); Serial.println(adcRes);
-		//Serial.print("edaFeedbackAmpR = "); Serial.println(edaFeedbackAmpR);
-		//Serial.print("edrAmplification = "); Serial.println(edrAmplification);
 		Serial.print("LED Driver Current Level = "); Serial.println(_emotiBitSystemConstants[(int)SystemConstants::LED_DRIVER_CURRENT]);
 	}
 	
@@ -768,12 +764,9 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	// using correction values generated in AdcCorrectionMode
 	else
 	{
-		if (testingMode == TestingMode::ACUTE || testingMode == TestingMode::CHRONIC)
-		{
-			Serial.println("ADC correction already enabled in correction test mode");
-			Serial.print("Gain Correction:"); Serial.print(adcCorrectionValues._gainCorrection);
-			Serial.print("\toffset correction:"); Serial.println(adcCorrectionValues._offsetCorrection);
-		}
+		Serial.println("ADC correction already enabled in correction test mode");
+		Serial.print("Gain Correction:"); Serial.print(adcCorrectionValues._gainCorrection);
+		Serial.print("\toffset correction:"); Serial.println(adcCorrectionValues._offsetCorrection);
 	}
 
 
@@ -3334,10 +3327,8 @@ void EmotiBit::processDebugInputs(String &debugPackets, uint16_t &packetNumber)
 			Serial.println("Press f to print the FW version");
 			Serial.println("press | to enable Digital filters");
 			Serial.println("Press - to disable Digital filters");
-			//Serial.println("Press 0 to simulate nan events in the thermopile");
-			Serial.println("Press F to switch to FactoryTest mode");
-
-
+			Serial.println("[ACUTE TESTING MODE] Press s to disable Digital filters");
+			Serial.println("[ACUTE TESTING MODE] Press c to disable Digital filters");
 		}
 		else if (c == ':')
 		{
@@ -3567,57 +3558,6 @@ void EmotiBit::processDebugInputs(String &debugPackets, uint16_t &packetNumber)
 			_enableDigitalFilter.mz = false;
 			_enableDigitalFilter.eda = false;
 		}
-		else if (c == '+')
-		{
-			if (_hwVersion == EmotiBitVersionController::EmotiBitVersion::V04A && testingMode == TestingMode::FACTORY_TEST)
-			{
-				static const uint32_t ARRAY_SIZE = 10;
-				char cArray[ARRAY_SIZE] = { 'a','b','c','d','e','1','2','3','4','5' };
-				// write a struct of data to the EEPROM
-				Serial.println("Testing NVM Controller. Writing to EEPROM(Location VARIANT_INFO)");
-				Serial.println("Writing to EEPROM: ");
-				for (int i = 0; i < ARRAY_SIZE; i++)
-				{
-					Serial.print(cArray[i]); Serial.print("\t");
-				}
-				uint8_t status;
-				status = _emotibitNvmController.stageToWrite(EmotiBitNvmController::DataType::VARIANT_INFO, 0, ARRAY_SIZE, (uint8_t*)cArray);
-				if (status == 0)
-				{
-					Serial.println("\nWrite successful");
-				}
-				else
-				{
-					Serial.print("Write unsuccessful. ErrorCode: "); Serial.println(status);
-				}
-				Serial.println("Reading from EEPROM");
-				uint8_t* data = nullptr;
-				uint32_t dataSize = 0;
-				uint8_t dataVersion = 0;
-				char* cData;
-				status = _emotibitNvmController.stageToRead(EmotiBitNvmController::DataType::VARIANT_INFO, dataVersion, dataSize, data);
-				cData = (char*)data;
-				if (status == 0)
-				{
-					Serial.print("Version Read: "); Serial.println(dataVersion);
-					Serial.println("Data Read: ");
-					for (int i = 0; i < dataSize; i++)
-					{
-						Serial.print(cData[i]); Serial.print("\t");
-					}
-				}
-				else
-				{
-					Serial.print("Read unsuccessful. ErrorCode: "); Serial.println(status);
-				}
-				delete[] data;
-				Serial.println("Read Successful");
-			}
-			else
-			{
-				Serial.println("Cannot test NVM for this HW version.");
-			}
-		}
 		else if (c == 's') 
 		{
 			if (testingMode == TestingMode::ACUTE)
@@ -3627,18 +3567,9 @@ void EmotiBit::processDebugInputs(String &debugPackets, uint16_t &packetNumber)
 		}
 		else if (c == 'c')
 		{
-			if (testingMode == TestingMode::FACTORY_TEST)
+			if (testingMode == TestingMode::ACUTE)
 			{
 				_emotibitNvmController.eraseEeprom();
-			}
-		}
-		else if (c == 'F')
-		{
-		// switch to factory test mode using Serial
-			if (testingMode == TestingMode::NONE)
-			{
-				testingMode = TestingMode::FACTORY_TEST;
-				Serial.print("Testing Mode: "); Serial.println("FACTORY TEST");
 			}
 		}
 	}

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -1119,6 +1119,7 @@ bool EmotiBit::addPacket(uint32_t timestamp, const String typeTag, float * data,
 	addPacketHeader(timestamp, typeTag, dataLen, protocolVersion, printToSerial);
 	// Add packet data to _outDataPackets
 	addPacketData(data, dataLen, precision, printToSerial);
+	_outDataPackets += "\n";
 	return true;
 }
 

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -110,6 +110,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 		input = Serial.read();
 		if (input == EmotiBitFactoryTest::INIT_FACTORY_TEST)
 		{
+			uint32_t waitStarForBarcode = millis();
 			testingMode = TestingMode::FACTORY_TEST;
 			String ackString;
 			ackString += EmotiBitFactoryTest::MSG_START_CHAR;
@@ -129,6 +130,8 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 					barcode.rawCode = Serial.readStringUntil('*');
 					barcodeReceived = true;
 				}
+				if (millis() - waitStarForBarcode > 3000)
+					break;
 			}
 		}
 		// remove any other char in the buffer before proceeding
@@ -263,7 +266,8 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	{
 		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::FIRMWARE_VERSION, firmware_version.c_str());
 		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::EMOTIBIT_VERSION, EmotiBitVersionController::getHardwareVersion(_hwVersion));
-		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::EMOTIBIT_NUMBER, barcode.emotibitSerialNumber.c_str());
+		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::EMOTIBIT_SERIAL_NUMBER, String(emotibitSerialNumber).c_str());
+		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::EMOTIBIT_SKU_TYPE, emotiBitSku.c_str());
 	}
 	//Serial.println("All Serial inputs must be used with **No Line Ending** option from the serial monitor");
 

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -1987,74 +1987,6 @@ int8_t EmotiBit::pushData(EmotiBit::DataType type, float data, uint32_t * timest
 	}
 }
 
-void EmotiBit::processElectrodermalResponse()
-{
-	static const float samplingFrequency = _samplingRates.eda / _samplesAveraged.eda;
-	static const float timePeriod = 1 / samplingFrequency; // in secs
-	static DigitalFilter edaLowpassFilter(DigitalFilter::FilterType::IIR_LOWPASS, samplingFrequency, 1); // for bandpassing eda
-	static DigitalFilter edaHighpassFilter(DigitalFilter::FilterType::IIR_HIGHPASS, samplingFrequency, 0.2); // for bandpassing eda
-	static DigitalFilter edrFrequencyFilter(DigitalFilter::FilterType::IIR_LOWPASS, samplingFrequency, 1); // lowPass the calculated frequency
-	float* data;
-	uint32_t timestamp;
-	size_t dataSize;
-	static uint32_t interResposeSampleCount = 0; // to count number of samples passed between EDR events
-	static const float threshold = 5000; // detect an onset if delta eda > threshold
-	static bool onsetDetected = false;
-	static float edrAmplitudeOnOnset;
-	static uint32_t onsetTime;  // in mS
-	static float responseFreq;  // in mins
-	static const uint8_t APERIODIC_DATA_LEN = 1; // constant for adding packet
-	// Load latest EDA signal
-	dataSize = dataDoubleBuffers[(uint8_t)EmotiBit::DataType::EDA]->getData(&data, &timestamp, false);
-
-	for (size_t i = 0; i < dataSize; i++)
-	{
-		interResposeSampleCount++;
-		// bandpass filter eda
-		float filteredEda = edaLowpassFilter.filter(data[i]);
-		filteredEda = edaHighpassFilter.filter(filteredEda);
-		if (!onsetDetected)
-		{
-			float instSkinResistance = 1000000 / data[i];  // Instantaneous skin Resistance
-			float baselineSkinResistance = 1000000 / (data[i] - filteredEda); // Resistance before Response
-
-			// detect onset if threshold is crossed
-			if(baselineSkinResistance - instSkinResistance > threshold)
-			{
-				onsetDetected = true;
-				
-				//back calculate time based on buffer timestamp
-				float timeAdjustment = (dataSize - i - 1) * timePeriod * 1000; // in mS
-				onsetTime = timestamp - (uint32_t)timeAdjustment; // mS
-				edrAmplitudeOnOnset = data[i];  // record the base of the EDA peak
-				
-				// Calculate interResponseTime. interResponseTime = t = NxT => 1/t = 1/(N*T) = fs/N, where T = 1/fs
-				responseFreq = (float)samplingFrequency / (float)interResposeSampleCount; 
-				responseFreq *= 60; // convert to event/min
-				responseFreq = edrFrequencyFilter.filter(responseFreq);  // low pass filtewr data
-				// reset counter for next response
-				interResposeSampleCount = 0;
-			}
-		}
-		else
-		{
-			// wait for a peak
-			if (data[i] < data[i - 1])
-			{
-				// peak detected. calculate rise time and amplitude
-				onsetDetected = false;
-				float amplitude = data[i - 1] - edrAmplitudeOnOnset;
-				float riseTime = (float)interResposeSampleCount * timePeriod; // Samples since onset*timePeriod (in Secs)
-
-				// Add packet to the output
-				addPacket(onsetTime, EmotiBitPacket::TypeTag::ELECTRODERMAL_RESPONSE_FREQ, &responseFreq, APERIODIC_DATA_LEN, 4); // 4 = precision
-				addPacket(onsetTime, EmotiBitPacket::TypeTag::ELECTRODERMAL_RESPONSE_CHANGE, &amplitude, APERIODIC_DATA_LEN, 4); // 4 = precision
-				addPacket(onsetTime, EmotiBitPacket::TypeTag::ELECTRODERMAL_RESPONSE_RISE_TIME, &riseTime, APERIODIC_DATA_LEN, 4); // 4 = precision
-			}
-		}
-	}
-}
-
 bool EmotiBit::processThermopileData()
 {
 #ifdef DEBUG_THERM_PROCESS
@@ -3058,7 +2990,7 @@ void EmotiBit::processData()
 		}
 		if (acquireData.edrMetrics)
 		{
-			processElectrodermalResponse();
+			emotibitEda.processElectrodermalResponse(this);
 
 		}
 	}

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.23";
+	String firmware_version = "1.3.24";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.14";
+	String firmware_version = "1.3.15";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.20";
+	String firmware_version = "1.3.21";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.15";
+	String firmware_version = "1.3.16-HR";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.18";
+	String firmware_version = "1.3.19";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;
@@ -383,7 +383,6 @@ public:
 	void processData();
 	void sendData();
 	bool processThermopileData();	// placeholder until separate EmotiBitThermopile controller is implemented
-	void processElectrodermalResponse();
 	void writeSerialData(EmotiBit::DataType t);
 	
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.17";
+	String firmware_version = "1.3.18";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;
@@ -374,8 +374,6 @@ public:
 	bool writeSdCardMessage(const String &s);
 	int freeMemory();
 	bool loadConfigFile(const String &filename);
-	void addPacketData(float* data, size_t dataLen, uint8_t precision, bool printToSerial = false);
-	void addPacketHeader(uint32_t timestamp, const String typeTag, size_t dataLen, uint8_t protocolVersion, bool printToSerial = false);
 	bool addPacket(uint32_t timestamp, const String typeTag, float * data, size_t dataLen, uint8_t precision = 0, bool printToSerial = false);
 	bool addPacket(uint32_t timestamp, EmotiBit::DataType t, float * data, size_t dataLen, uint8_t precision = 4);
 	bool addPacket(EmotiBit::DataType t);

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -43,7 +43,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.12";
+	String firmware_version = "1.3.13";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;
@@ -371,6 +371,9 @@ public:
 	bool writeSdCardMessage(const String &s);
 	int freeMemory();
 	bool loadConfigFile(const String &filename);
+	void addPacketData(float* data, uint16_t dataLen, uint8_t precision, bool printToSerial = false);
+	void addPacketHeader(uint32_t timestamp, const String typeTag, uint16_t dataLen, uint8_t protocolVersion, bool printToSerial = false);
+	bool addPacket(uint32_t timestamp, const String typeTag, float * data, size_t dataLen, uint8_t precision = 0);
 	bool addPacket(uint32_t timestamp, EmotiBit::DataType t, float * data, size_t dataLen, uint8_t precision = 4);
 	bool addPacket(EmotiBit::DataType t);
 	void parseIncomingControlPackets(String &controlPackets, uint16_t &packetNumber);

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -30,6 +30,7 @@
 #include "EmotiBitEda.h"
 #include "EmotiBitVariants.h"
 #include "EmotiBitNvmController.h"
+#include "heartRate.h"
 
 class EmotiBit {
   
@@ -43,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.13";
+	String firmware_version = "1.3.14";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;
@@ -315,6 +316,7 @@ public:
 		bool tempPpg = true;
 		bool debug = false;
 		bool battery = true;
+		bool heartRate = true;
 	} acquireData;
 
 	struct ChipBegun {
@@ -371,13 +373,14 @@ public:
 	bool writeSdCardMessage(const String &s);
 	int freeMemory();
 	bool loadConfigFile(const String &filename);
-	void addPacketData(float* data, uint16_t dataLen, uint8_t precision, bool printToSerial = false);
-	void addPacketHeader(uint32_t timestamp, const String typeTag, uint16_t dataLen, uint8_t protocolVersion, bool printToSerial = false);
+	void addPacketData(float* data, size_t dataLen, uint8_t precision, bool printToSerial = false);
+	void addPacketHeader(uint32_t timestamp, const String typeTag, size_t dataLen, uint8_t protocolVersion, bool printToSerial = false);
 	bool addPacket(uint32_t timestamp, const String typeTag, float * data, size_t dataLen, uint8_t precision = 0);
 	bool addPacket(uint32_t timestamp, EmotiBit::DataType t, float * data, size_t dataLen, uint8_t precision = 4);
 	bool addPacket(EmotiBit::DataType t);
 	void parseIncomingControlPackets(String &controlPackets, uint16_t &packetNumber);
 	void readSensors();
+	void processHeartRate();
 	void processData();
 	void sendData();
 	bool processThermopileData();	// placeholder until separate EmotiBitThermopile controller is implemented

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -43,7 +43,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.0";
+	String firmware_version = "1.3.1";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.19";
+	String firmware_version = "1.3.20";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -43,7 +43,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.1";
+	String firmware_version = "1.3.2";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.21";
+	String firmware_version = "1.3.22";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;
@@ -316,7 +316,7 @@ public:
 		bool tempPpg = true;
 		bool debug = false;
 		bool battery = true;
-		bool heartRate = true;
+		bool heartRate = true; // Note: we may want to move this to a separarte flag someday, for controlling derivative signals
 		bool edrMetrics = true;
 	} acquireData;
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.24";
+	String firmware_version = "1.3.25";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.22";
+	String firmware_version = "1.3.23";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBitEda.cpp
+++ b/EmotiBitEda.cpp
@@ -639,8 +639,8 @@ void EmotiBitEda::processElectrodermalResponse(EmotiBit* emotibit)
 				float riseTime = (float)(riseTimeSampleCount-1)  * timePeriod; // Samples since onset*timePeriod (in Secs)
 
 				// Add packet to the output
-				emotibit->addPacket(onsetTime, EmotiBitPacket::TypeTag::ELECTRODERMAL_RESPONSE_CHANGE, &amplitude, APERIODIC_DATA_LEN, 4); // 4 = precision
-				emotibit->addPacket(onsetTime, EmotiBitPacket::TypeTag::ELECTRODERMAL_RESPONSE_RISE_TIME, &riseTime, APERIODIC_DATA_LEN, 4); // 4 = precision
+				emotibit->addPacket(onsetTime, EmotiBitPacket::TypeTag::SKIN_CONDUCTANCE_RESPONSE_AMPLITUDE, &amplitude, APERIODIC_DATA_LEN, 4); // 4 = precision
+				emotibit->addPacket(onsetTime, EmotiBitPacket::TypeTag::SKIN_CONDUCTANCE_RESPONSE_RISE_TIME, &riseTime, APERIODIC_DATA_LEN, 4); // 4 = precision
 			}
 		}
 		// check if it time to send EDR:FREQ packet
@@ -651,7 +651,7 @@ void EmotiBitEda::processElectrodermalResponse(EmotiBit* emotibit)
 			responseFreq = edrFrequencyFilter.filter(responseFreq);
 			uint32_t timstamp = millis();
 			// send data
-			emotibit->addPacket(timestamp, EmotiBitPacket::TypeTag::ELECTRODERMAL_RESPONSE_FREQ, &responseFreq, APERIODIC_DATA_LEN, 4); // 4 = precision
+			emotibit->addPacket(timestamp, EmotiBitPacket::TypeTag::SKIN_CONDUCTANCE_RESPONSE_FREQ, &responseFreq, APERIODIC_DATA_LEN, 4); // 4 = precision
 			edrOnsetCount = 0;
 			edrFreqOutputCounter = 0;
 		}

--- a/EmotiBitEda.cpp
+++ b/EmotiBitEda.cpp
@@ -584,8 +584,9 @@ void EmotiBitEda::processElectrodermalResponse(EmotiBit* emotibit)
 	static uint32_t onsetTime;  // in mS
 	static float responseFreq;  // in mins
 	static const uint8_t APERIODIC_DATA_LEN = 1; // constant for adding packet
-	static const uint16_t INTER_EDR_FREQ_UPDATE_SAMPLE_COUNT = 15; // EDR:FREQ is sent every X * (1/sampingRte)
-	static float secToMinMultiplier = 60 / (INTER_EDR_FREQ_UPDATE_SAMPLE_COUNT * timePeriod);  // multiplier used below to convert events/(n secs) -> events/min
+	static const uint16_t INTER_EDR_FREQ_UPDATE_SAMPLE_COUNT = 5; // a  EDR FREQ sample is sent every X EDA counts
+	static const float edrFreqTimePeriod = INTER_EDR_FREQ_UPDATE_SAMPLE_COUNT * timePeriod; // timePeriod of EDR:FREQ
+	static const float secToMinMultiplier = 60 / (edrFreqTimePeriod);  // multiplier used below to convert events/(n secs) -> events/min
 	static uint16_t edrOnsetCount = 0;
 	static uint16_t edaSamplesCount = 0;
 	// Load latest EDA signal
@@ -638,7 +639,7 @@ void EmotiBitEda::processElectrodermalResponse(EmotiBit* emotibit)
 		}
 		if (edaSamplesCount == INTER_EDR_FREQ_UPDATE_SAMPLE_COUNT)
 		{
-			float responseFreq = (edrOnsetCount / (INTER_EDR_FREQ_UPDATE_SAMPLE_COUNT * timePeriod)) * secToMinMultiplier; // EDR:FREQ in count/min
+			float responseFreq = (edrOnsetCount / edrFreqTimePeriod) * secToMinMultiplier; // EDR:FREQ in count/min
 			responseFreq = edrFrequencyFilter.filter(responseFreq);
 			uint32_t timstamp = millis();
 			emotibit->addPacket(timestamp, EmotiBitPacket::TypeTag::ELECTRODERMAL_RESPONSE_FREQ, &responseFreq, APERIODIC_DATA_LEN, 4, true); // 4 = precision

--- a/EmotiBitEda.cpp
+++ b/EmotiBitEda.cpp
@@ -559,6 +559,7 @@ bool EmotiBitEda::writeInfoJson(File &jsonFile)
 #endif
 		}
 	}
+	jsonFile.print(",");
 	// Skin Coductance Response Amplitude
 	{
 		// Parse the root object
@@ -583,6 +584,7 @@ bool EmotiBitEda::writeInfoJson(File &jsonFile)
 #endif
 		}
 	}
+	jsonFile.print(",");
 	// Skin Coductance Response Frequency
 	{
 		// Parse the root object
@@ -608,7 +610,8 @@ bool EmotiBitEda::writeInfoJson(File &jsonFile)
 #endif
 		}
 	}
-		// Skin Coductance Response Rise Time
+	jsonFile.print(",");
+	// Skin Coductance Response Rise Time
 	{
 		// Parse the root object
 		StaticJsonBuffer<bufferSize> jsonBuffer;

--- a/EmotiBitEda.h
+++ b/EmotiBitEda.h
@@ -50,6 +50,7 @@ public:
 	{
 		float edaSeriesResistance = 0.f;	//Ohms
 		float samplingRate = 15.f;	// Hz
+		static const uint16_t EDA_SAMPLES_PER_SCR_FREQ_OUTPUT = 5; // = {X}. A  EDR FREQ sample is sent every {X} EDA counts
 		uint8_t adcBits;	// Bit resolution of ADC, e.g. 12, 16
 		bool enableDigitalFilter = false;
 		int16_t clipMin;	// Min value before clipping occurs

--- a/EmotiBitEda.h
+++ b/EmotiBitEda.h
@@ -28,7 +28,9 @@
 #include <math.h> 
 #include "DoubleBufferFloat.h"
 #include "DigitalFilter.h"
+#include "EmotiBitPacket.h"
 
+class EmotiBit; // forward declaration to enable compile
 
 class EmotiBitEda
 {
@@ -134,6 +136,12 @@ public:
 		@param isrOffsetCorr Sets the ISR offset correction value
 	*/
 	void setAdcIsrOffsetCorr(float isrOffsetCorr);
+
+	/*!
+		@brief Processes and records Electrodermal Response
+		@param pointer to emotibit instance. Required for adding outDataPacket
+	*/
+	void processElectrodermalResponse(EmotiBit* emotibit);
 };
 
 #endif

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit FeatherWing
-version=1.2.78
+version=1.3.12
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A library written for EmotiBit FeatherWing that supports all sensors included on the wing.

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph= Requires dependent libraries as shown in the getting started document
 category=Sensors
 url=https://github.com/EmotiBit/EmotiBit_FeatherWing
 architectures=*
+depends=EmotiBit BMI160, EmotiBit MAX30101, EmotiBit MLX90632, EmotiBit NCP5623, EmotiBit SI7013, EmotiBit XPlat Utils


### PR DESCRIPTION
# Description
- Adds `HR` and `EDR` derivatve metrics

# Requirements
- https://github.com/EmotiBit/EmotiBit_XPlat_Utils/pull/15
- to test: https://github.com/EmotiBit/ofxEmotiBit/pull/84

# Issues resolved
- #172 
- #173 

# Tests
|Test | Process| Results|
|---|----|---|
|Test `addpacket()` functionality after change| Send `S+:Typetag~` over serial in factory test mode| PASS|
|Record| init record session | data recordign works and packet structure is maintained|
|Data Parser| Test by parsing recorded data| PASS. data parser successfully parser new data types|
|HR | view stream in oscilloscope| PASS. HR measured reasonably close to HR obtained using a oximeter|
|EDR Amplitude| view stream in oscilloscope | PASS. Amplitude detected in 100K, 1M, 10M|
|EDR Rise Time | view stream in oscilloscope  | PASS. Each EDR vent has an associated rise time|
|EDR Freq | view stream in oscilloscope |PASS. Freq of EDRs updates with each EDR|


# Testing
- Requirements new EmotiBit Oscilloscope

![image](https://user-images.githubusercontent.com/31810812/155614039-60d46c45-6351-4d9f-b0aa-4aaa920ec3c0.png)
