### PR TITLE
Features new LED light up sequence during bootup

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -201,8 +201,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 			EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::SETUP_COMPLETE, EmotiBitFactoryTest::TypeTag::TEST_FAIL);
 			Serial.println(factoryTestSerialOutput);
 		}
-		//sleep(false);
-		sensorSetupFailed("EEPROM");
+		setupFailed("EEPROM");
 	}
 	if (testingMode == TestingMode::FACTORY_TEST && barcode.rawCode != "")
 	{
@@ -247,8 +246,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	{
 		if (!emotiBitVersionController.detectVariantFromHardware(*(_EmotiBit_i2c), _hwVersion, emotiBitSku))
 		{
-			//sleep(false);
-			sensorSetupFailed("CANNOT IDENTIFY HARDWARE");
+			setupFailed("CANNOT IDENTIFY HARDWARE");
 		}
 	}
 	// device ID for V3 and lower will be updated after Temp/Humidity sensor is setup below
@@ -294,8 +292,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	{
 		Serial.println("Constant Mapping Failed. Stopping execution");
 		emotiBitVersionController.initConstantMapping(EmotiBitVersionController::EmotiBitVersion::V03B);// Assume the version is V03B to set Hibernate level as Required
-		//sleep(false);
-		sensorSetupFailed("CONSTANT MAPPING");
+		setupFailed("CONSTANT MAPPING");
 	}
 
 #ifdef DEBUG
@@ -337,8 +334,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	if (!_outDataPackets.reserve(OUT_MESSAGE_RESERVE_SIZE)) {
 		Serial.println("Failed to reserve memory for output");
 		while (true) {
-			//sleep(false);// hiberante with setup incomplete
-			sensorSetupFailed("FAILED TO RESERVE MEM FOR OUT MESSAGE");
+			setupFailed("FAILED TO RESERVE MEM FOR OUT MESSAGE");
 		}
 	}
 	now = millis();
@@ -495,8 +491,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 		{
 			EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::LED_CONTROLLER, EmotiBitFactoryTest::TypeTag::TEST_FAIL);
 			Serial.println(factoryTestSerialOutput);
-			//sleep(false);
-			sensorSetupFailed("LED CONTROLLER");
+			setupFailed("LED CONTROLLER");
 		}
 	}
 	
@@ -519,8 +514,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 		{
 			EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::PPG_SENSOR, EmotiBitFactoryTest::TypeTag::TEST_FAIL);
 			Serial.println(factoryTestSerialOutput);
-			//sleep(false);
-			sensorSetupFailed("PPG");
+			setupFailed("PPG");
 		}
 	}
 	ppgSensor.wakeUp();
@@ -664,8 +658,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 			EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::ACCEL_GYRO, EmotiBitFactoryTest::TypeTag::TEST_FAIL);		
 			Serial.println(factoryTestSerialOutput);
 		}
-		//sleep(false);
-		sensorSetupFailed("IMU");
+		setupFailed("IMU");
 	}
 	if ((int)_hwVersion == (int)EmotiBitVersionController::EmotiBitVersion::V03B)
 	{
@@ -726,8 +719,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 				EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::TEMP_SENSOR, EmotiBitFactoryTest::TypeTag::TEST_FAIL);
 				Serial.println(factoryTestSerialOutput);
 			}
-			//sleep(false);
-			sensorSetupFailed("TEMP/HUMIDITY");
+			setupFailed("TEMP/HUMIDITY");
 		}
 		Serial.println(" ... Completed");
 	}
@@ -769,8 +761,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 				EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::THERMOPILE, EmotiBitFactoryTest::TypeTag::TEST_FAIL);
 			}
 			Serial.println("Failed");
-			//sleep(false);
-			sensorSetupFailed("THERMOPILE");
+			setupFailed("THERMOPILE");
 		}
 	}
 
@@ -1044,12 +1035,12 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 } // Setup
 
 
-void EmotiBit::sensorSetupFailed(const String failureMode)
+void EmotiBit::setupFailed(const String failureMode)
 {
 	while (1)
 	{
 		Serial.println("Failed to setup: " + failureMode);
-		Serial.println("please contact info@emotibit.com");
+		Serial.println("please contact info@emotibit.com\n");
 		delay(1000);
 	}
 }

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -815,8 +815,6 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 
 	// Sensor setup complete
 	Serial.println("Sensor setup complete");
-	//led.setLED(uint8_t(EmotiBit::Led::YELLOW), true);
-	//led.send();
 
 	// EDL Filter Parameters
 	//edaCrossoverFilterFreq = emotiBitVersionController.getMathConstant(MathConstants::EDA_CROSSOVER_FILTER_FREQ);
@@ -982,15 +980,6 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	Serial.println("Free Ram :" + String(freeMemory(), DEC) + " bytes");
 	Serial.print("\n");
 	uint8_t ledOffdelay = 100;	// Aesthetic delay
-	// below block no longer required as light up seq. changed
-	/*
-	led.setLED(uint8_t(EmotiBit::Led::RED), false);
-	delay(ledOffdelay);
-	led.setLED(uint8_t(EmotiBit::Led::BLUE), false);
-	delay(ledOffdelay);
-	led.setLED(uint8_t(EmotiBit::Led::YELLOW), false);
-	led.send();
-	*/
 	if (!_sendTestData)
 	{
 		attachToInterruptTC3(&ReadSensors, this);
@@ -1084,10 +1073,7 @@ bool EmotiBit::setupSdCard()
 		Serial.println("Create a file 'config.txt' with the following JSON:");
 		Serial.println("{\"WifiCredentials\": [{\"ssid\":\"SSSS\",\"password\" : \"PPPP\"}]}");
 		// ToDo: verify if we need a separate case for FACTORY_TEST. We should always have a config file, since FACTORY TEST is a controlled environment
-		while (true) {
-			Serial.println("Config file not found. Please add a config file to the SD-Card.");
-			delay(1000);
-		}
+		setupFailed("Config file not found");
 	}
 
 	return true;

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -1028,8 +1028,7 @@ void EmotiBit::setupFailed(const String failureMode)
 {
 	while (1)
 	{
-		Serial.println("Failed to setup: " + failureMode);
-		Serial.println("please contact info@emotibit.com\n");
+		Serial.println("Setup failed: " + failureMode);
 		delay(1000);
 	}
 }

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.32";
+	String firmware_version = "1.3.33";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.31";
+	String firmware_version = "1.3.32";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;
@@ -357,6 +357,7 @@ public:
 	DataType _serialData = DataType::length;
 	volatile bool buttonPressed = false;
 
+	void sensorSetupFailed(const String failureMode);
 	bool setupSdCard();
 	void updateButtonPress();
 	void sleep(bool i2cSetupComplete = true);

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.33";
+	String firmware_version = "1.3.32.newLedSequence";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -357,7 +357,7 @@ public:
 	DataType _serialData = DataType::length;
 	volatile bool buttonPressed = false;
 
-	void sensorSetupFailed(const String failureMode);
+	void setupFailed(const String failureMode);
 	bool setupSdCard();
 	void updateButtonPress();
 	void sleep(bool i2cSetupComplete = true);

--- a/EmotiBitEda.cpp
+++ b/EmotiBitEda.cpp
@@ -649,7 +649,7 @@ void EmotiBitEda::processElectrodermalResponse(EmotiBit* emotibit)
 	static const float timePeriod = 1.f / samplingFrequency; // in secs
 	static const float scrFreqTimePeriod = _constants.EDA_SAMPLES_PER_SCR_FREQ_OUTPUT  * timePeriod; // timePeriod of the signal scr:FREQ
 	static const float secToMinMultiplier = 60.f / (scrFreqTimePeriod);  // multiplier used below to convert events/(n secs) -> events/min
-	static DigitalFilter edaLowpassFilter(DigitalFilter::FilterType::IIR_LOWPASS, samplingFrequency, 1.5); // for bandpassing eda
+	static DigitalFilter edaLowpassFilter(DigitalFilter::FilterType::IIR_LOWPASS, samplingFrequency, 1); // for bandpassing eda
 	static DigitalFilter edaHighpassFilter(DigitalFilter::FilterType::IIR_HIGHPASS, samplingFrequency, 0.2); // for bandpassing eda
 	static DigitalFilter scrFrequencyFilter(DigitalFilter::FilterType::IIR_LOWPASS, 1.f/(scrFreqTimePeriod), 0.01); // lowPass the calculated scr:FREQ
 	float* data;
@@ -673,10 +673,11 @@ void EmotiBitEda::processElectrodermalResponse(EmotiBit* emotibit)
 	{
 		dataSize = _edaBuffer->getData(&data, &timestamp, false);
 	}
+	// uncomment below comment block to TX new signals to the Oscilloscope
 	/*
 	// testing bandpass
-	static DigitalFilter edaLowpassFilterTest(DigitalFilter::FilterType::IIR_LOWPASS, samplingFrequency, 1); // for bandpassing eda
-	static DigitalFilter edaHighpassFilterTest(DigitalFilter::FilterType::IIR_HIGHPASS, samplingFrequency, 0.3); // for bandpassing eda
+	static DigitalFilter edaLowpassFilterTest(DigitalFilter::FilterType::IIR_LOWPASS, samplingFrequency, 1.5); // for bandpassing eda
+	static DigitalFilter edaHighpassFilterTest(DigitalFilter::FilterType::IIR_HIGHPASS, samplingFrequency, 0.2); // for bandpassing eda
 	float tempFiltered[10];
 	if (dataSize < 10)
 	{
@@ -702,7 +703,6 @@ void EmotiBitEda::processElectrodermalResponse(EmotiBit* emotibit)
 			// convert uS to Ohms for thresholding
 			float instSkinResistance = 1000000.f / data[i];  // Instantaneous skin Resistance
 			float baselineSkinResistance = 1000000.f / (data[i] - filteredEda); // Resistance before Response
-
 			// detect onset if threshold is crossed
 			if (baselineSkinResistance - instSkinResistance > threshold)
 			{
@@ -715,7 +715,7 @@ void EmotiBitEda::processElectrodermalResponse(EmotiBit* emotibit)
 				scrAmplitudeOnOnset = data[i];  // record the base of the EDA peak
 
 				// reset counter for next response
-				riseTimeSampleCount  = 0;
+				riseTimeSampleCount = 0;
 			}
 		}
 		else


### PR DESCRIPTION
# Description
- Introduces new light up sequence for EmotiBit during bootup.

# Requirements
- please close #183 first

# Related Issues
- https://github.com/EmotiBit/EmotiBit_FeatherWing/issues/184

# New behavior
- Feather RED LED glows up first. Stays on if SD-Card is detected, else turns OFF
- Only Feather RED LED stays on while sensors are being set up
- After sensor setup is complete, the EmotiBit RED LED turns on, indicating EmotiBit is scanning for config file.
- After config file is found EmotiBit RED turns off and EmotiBit BLUE turns on.
- After EmotiBit is connected to WIFI, Feather green light turns ON

# ToDo
- Replace `sleep` on no SD-Card to `while(1)` 