### PR TITLE
Added fix to prevent false detection from being logged in data

### DIFF
--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.33";
+	String firmware_version = "1.3.33.fixScr";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -44,7 +44,7 @@ public:
 		length
 	};
 
-	String firmware_version = "1.3.33.fixScr";
+	String firmware_version = "1.3.34";
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 	const bool DC_DO_V2 = true;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit FeatherWing
-version=1.3.33
+version=1.3.34
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A library written for EmotiBit FeatherWing that supports all sensors included on the wing.


### PR DESCRIPTION
# Description
Fixes an issue with false detection of SCR events

# Issues referenced
- fixes #188 

# Test
- Data was recorded with the fix implements. Only SCR events with Amplitude > 0 were recorded in the data.
- Also check out comments in #188 for verified false detections.
