### PR TITLE
Feat buffer limit test

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -4415,17 +4415,15 @@ void EmotiBit::bufferOverflowTest(unsigned int maxTestDuration, unsigned int del
 	unsigned long startTime = millis();
 	unsigned int totalDuration = millis() - startTime;
 
+	Serial.println("Results format:");
+	Serial.print("totalDuration");
+	humanReadable ? Serial.println("") : Serial.print(", ");
+	Serial.println("TypeTag, size, capacity, overflowCount");
+
 	while (totalDuration < maxTestDuration)
 	{
 		Serial.print(totalDuration);
-		if (humanReadable)
-		{
-			Serial.println("");
-		}
-		else
-		{
-			Serial.print(",");
-		}
+		humanReadable ? Serial.println("") : Serial.print(", ");
 
 		for (uint8_t d = 0; d < (uint8_t) DataType::length; d++)
 		{
@@ -4437,14 +4435,7 @@ void EmotiBit::bufferOverflowTest(unsigned int maxTestDuration, unsigned int del
 			Serial.print(", ");
 			Serial.print(dataDoubleBuffers[(uint8_t)d]->getOverflowCount(DoubleBufferFloat::BufferSelector::IN));
 
-			if (humanReadable)
-			{
-				Serial.println("");
-			}
-			else
-			{
-				Serial.print(",");
-			}
+			humanReadable ? Serial.println("") : Serial.print(", ");
 		}
 		Serial.println("");
 		delay(delayInterval);

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -487,7 +487,7 @@ public:
 	* @param delayInterval Interval to poll buffers and print results
 	* @param humanReadable Boolean to switch between commas and carriage returns for human readability
 	*/
-	void bufferOverflowTest(unsigned int maxTestDuration = 3000, unsigned int delayInterval = 100, bool humanReadable = true);
+	void bufferOverflowTest(unsigned int maxTestDuration = 5000, unsigned int delayInterval = 100, bool humanReadable = true);
 	String getFeatherMacAddress();
 	String getHardwareVersion();
 	int detectEmotiBitVersion();
@@ -559,6 +559,7 @@ private:
 	uint8_t _imuFifoFrameLen = 0; // in bytes
 	const uint8_t _maxImuFifoFrameLen = 40; // in bytes
 	uint8_t _imuBuffer[40];
+
 #if defined(ARDUINO_FEATHER_ESP32)
 	const uint8_t BUFFER_SIZE_FACTOR = 2;
 #else

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -483,8 +483,8 @@ public:
 	void processFactoryTestMessages();
 	/**
 	* Test to assess buffer overflow duration limits
-	* @param maxTestDuration Total duration of test to assess overflows
-	* @param delayInterval Interval to poll buffers and print results
+	* @param maxTestDuration Total duration (in mS) of test to assess overflows
+	* @param delayInterval Interval (in mS) to poll buffers and print results
 	* @param humanReadable Boolean to switch between commas and carriage returns for human readability
 	*/
 	void bufferOverflowTest(unsigned int maxTestDuration = 5000, unsigned int delayInterval = 100, bool humanReadable = true);

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -48,7 +48,7 @@ public:
 		length
 	};
 
-  String firmware_version = "1.4.1.feat-bufferLimitTest.1";
+  String firmware_version = "1.4.1.feat-bufferLimitTest.2";
 
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -48,9 +48,9 @@ public:
 		length
 	};
 
-  String firmware_version = "1.4.1.feat-bufferLimitTest.0";
+  String firmware_version = "1.4.1.feat-bufferLimitTest.1";
 
-	TestingMode testingMode = TestingMode::ACUTE;
+	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
 #if defined (ARDUINO_FEATHER_ESP32)
 	const uint8_t DEBUG_OUT_PIN_0 = 26;


### PR DESCRIPTION
# Description
- Added a bufferOverflowTest() to print buffer size, capacity, overflowCount periodically to assess DoubleBuffer time intervals.
- Adjusted buffer sizes to enable 2.40 seconds of buffering on M0
- Added BUFFER_SIZE_FACTOR = 2 for ESP32 to enable 4.80 seconds of buffering

# Requirements
- none

# Issues Referenced
- none

# Documentation update
- none

# Testing
- In TestingMode::ACUTE enter 'o' in the serial monitor. Note the first totalDuration in which overflows are observed (third number after TypeTag. Note that some TypeTags are only updated in update() and thus do not increment.

|Test #| Feather | EmotiBit Version | Time for first overflow (mS) | console output |
|------|---------|--------------------|-------------------------------|-------------------|
| 1 |Feather M0 | v4 |  2370 | ![image](https://user-images.githubusercontent.com/31810812/202564479-faf111a2-c771-40e2-b85b-df09d06b0869.png)|
| 2 |Feather M0 | v4 | 2372 | ![image](https://user-images.githubusercontent.com/31810812/202564596-621b6eb4-2b03-4b1d-8241-dce93843ac86.png)|
| 3 | Feather ESP32 | v4 | 4919 | ![image](https://user-images.githubusercontent.com/31810812/202564975-f90ecb3b-0ea4-4dc9-b98e-73b54cd214a2.png)|
| 4 | Feather ESP32 | v4 | 4918 | ![image](https://user-images.githubusercontent.com/31810812/202565065-5ab2065b-68d2-4c21-bc74-2402138b694e.png)|
|5| Feather ESP32 | v3 | 4785 | ![image](https://user-images.githubusercontent.com/31810812/202565472-2805d968-3800-4633-8ea2-97aa00e4d03f.png)|
|6| Feather M0 | v3 | 2365 | ![image](https://user-images.githubusercontent.com/31810812/202565698-254b9e07-fc0e-4a7d-a3ae-b7c769b21017.png)|



# Checklist:
- [x] All dependent repositories used were on branch `master`
- [x] Release checklist completed (FW/ SW)
  - Make sure the required settings have been set to default before merging into master.
- [x] doxygen style comments included
- [x] Required documentation udpated

## Screenshots:
