### PR TITLE
Feat detect LDO fail

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -1123,7 +1123,7 @@ void EmotiBit::setupFailed(const String failureMode, int buttonPin)
 			if (buttonState == false)
 			{
 				Serial.println("\n\n**** Button Press Detected (DVDD is Working) ****\n\n");
-				return;
+				// return;
 			}
 			buttonState = true;
 		}

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -1122,7 +1122,7 @@ void EmotiBit::setupFailed(const String failureMode, int buttonPin)
 			
 			if (buttonState == false)
 			{
-				Serial.println("\n\n**** Button Press Detected (DVDD is Working) ****\n\n");
+				Serial.println("**** Button Press Detected (DVDD is Working) ****");
 				// return;
 			}
 			buttonState = true;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -48,7 +48,7 @@ public:
 		length
 	};
 
-  String firmware_version = "1.4.2";
+  String firmware_version = "1.4.2.feat-detectLdoFail.0";
 
 	TestingMode testingMode = TestingMode::NONE;
 	const bool DIGITAL_WRITE_DEBUG = false;
@@ -402,7 +402,7 @@ public:
 	DataType _serialData = DataType::length;
 	volatile bool buttonPressed = false;
 
-	void setupFailed(const String failureMode);
+	void setupFailed(const String failureMode, int buttonPin = -1);
 	bool setupSdCard();
 	void updateButtonPress();
 	void sleep(bool i2cSetupComplete = true);

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -77,13 +77,14 @@ bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiB
 	_assignedPin[(int)EmotiBitPinName::SPI_MOSI] = 23;
 	_assignedPin[(int)EmotiBitPinName::SPI_MISO] = 22;
 
+	_assignedPin[(int)EmotiBitPinName::EMOTIBIT_BUTTON] = 12;
+	_assignedPin[(int)EmotiBitPinName::PPG_INT] = 15;
+	_assignedPin[(int)EmotiBitPinName::BMI_INT1] = 5;
+	_assignedPin[(int)EmotiBitPinName::BMI_INT2] = 10;
+	_assignedPin[(int)EmotiBitPinName::BMM_INT] = 14;
+
 	if (version == EmotiBitVersion::V02B || version == EmotiBitVersion::V02H || version == EmotiBitVersion::V03B || version == EmotiBitVersion::V04A)
 	{
-		_assignedPin[(int)EmotiBitPinName::EMOTIBIT_BUTTON] = 12;
-		_assignedPin[(int)EmotiBitPinName::PPG_INT] = 15;
-		_assignedPin[(int)EmotiBitPinName::BMI_INT1] = 5;
-		_assignedPin[(int)EmotiBitPinName::BMI_INT2] = 10;
-		_assignedPin[(int)EmotiBitPinName::BMM_INT] = 14;
 	}
 	else if (version == EmotiBitVersion::V01B || version == EmotiBitVersion::V01C)
 	{
@@ -116,14 +117,25 @@ bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiB
 	_assignedPin[(int)EmotiBitPinName::SPI_MOSI] = 18;
 	_assignedPin[(int)EmotiBitPinName::SPI_MISO] = 19;
 
+	_assignedPin[(int)EmotiBitPinName::EMOTIBIT_BUTTON] = 12;
+	_assignedPin[(int)EmotiBitPinName::PPG_INT] = 25;
+	_assignedPin[(int)EmotiBitPinName::BMI_INT1] = 14;
+	_assignedPin[(int)EmotiBitPinName::BMI_INT2] = 33;
+	_assignedPin[(int)EmotiBitPinName::BMM_INT] = 26;
+
 	if (version == EmotiBitVersion::V02B || version == EmotiBitVersion::V02H || version == EmotiBitVersion::V03B || version == EmotiBitVersion::V04A)
 	{
-		_assignedPin[(int)EmotiBitPinName::EMOTIBIT_BUTTON] = 12;
-		_assignedPin[(int)EmotiBitPinName::PPG_INT] = 25;
-		_assignedPin[(int)EmotiBitPinName::BMI_INT1] = 14;
-		_assignedPin[(int)EmotiBitPinName::BMI_INT2] = 33;
-		_assignedPin[(int)EmotiBitPinName::BMM_INT] = 26;
 	}
+	else
+	{
+		// unknown version
+		Serial.println("Unknown Version");
+		return false;
+	}
+#else 
+	// unknown version
+	Serial.println("Unknown Feather");
+	return false;
 #endif
 	return true;
 }


### PR DESCRIPTION
# Description
Added a feature to detect LDO failures in the `SD-Card not detected` state by pressing the `EmotiBit Button`

# Requirements
- none


# Issues Referenced
<!-- If Any -->
- Fixes #236 

# Documentation update
none

# Testing
Booting EmotiBit without SD card `SD-Card not detected` state. Pressing the button prints `Button Press Detected`. 

## Screenshots:
![image](https://user-images.githubusercontent.com/537062/201224914-89f34f46-2655-4b27-8ab8-501ab63a936c.png)
