### PR TITLE
Added EmotiBit HW version v05c support

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -110,7 +110,7 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 
 	EmotiBitVersionController emotiBitVersionController;
 	//EmotiBitUtilities::printFreeRAM("Begining of setup", 1);
-	Serial.print("I2C data pin:"); Serial.println(EmotiBitVersionController::EMOTIBIT_I2C_DAT_PIN);
+	Serial.print("I2C data pin: "); Serial.println(EmotiBitVersionController::EMOTIBIT_I2C_DAT_PIN);
 	Serial.print("I2C clk pin: "); Serial.println(EmotiBitVersionController::EMOTIBIT_I2C_CLK_PIN);
 	Serial.print("hibernate pin: "); Serial.println(EmotiBitVersionController::HIBERNATE_PIN);
 	Serial.print("chip sel pin: "); Serial.println(EmotiBitVersionController::SD_CARD_CHIP_SEL_PIN);

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -49,7 +49,7 @@ public:
 	};
 
 
-  String firmware_version = "1.5.1";
+  String firmware_version = "1.5.1-feat-v05c-support.0";
 
 
 	TestingMode testingMode = TestingMode::NONE;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -49,7 +49,7 @@ public:
 	};
 
 
-  String firmware_version = "1.5.1-feat-v05c-support.0";
+  String firmware_version = "1.5.1-feat-v05c-support.1";
 
 
 	TestingMode testingMode = TestingMode::NONE;

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -5,6 +5,7 @@
 	@mainpage Controls reading Version from NVM on start or detecting version if NVM not updated, EmotiBit pin and constant asignment on startup
 	@section intro_sec Introduction
 	This is a library to handle EmotiBit HW version detection/version retrieval from NVM on setup.
+	See also "FW update instructions to support new HW version (EmotiBit).gdoc"
 	
 	EmotiBit invests time and resources providing this open source code,
 	please support EmotiBit and open-source hardware by purchasing
@@ -62,6 +63,10 @@ const char* EmotiBitVersionController::getHardwareVersion(EmotiBitVersion versio
 	{
 		return "V04a\0";
 	}
+	else if (version == EmotiBitVersion::V05C)
+	{
+		return "v05c\0";
+	}
 	else
 	{
 		return "NA\0";
@@ -82,15 +87,21 @@ bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiB
 	_assignedPin[(int)EmotiBitPinName::BMI_INT1] = 5;
 	_assignedPin[(int)EmotiBitPinName::BMI_INT2] = 10;
 	_assignedPin[(int)EmotiBitPinName::BMM_INT] = 14;
+	_assignedPin[(int)EmotiBitPinName::ADS_RDY] = -1;
 
-	if (version == EmotiBitVersion::V02B || version == EmotiBitVersion::V02H || version == EmotiBitVersion::V03B || version == EmotiBitVersion::V04A)
-	{
-	}
-	else if (version == EmotiBitVersion::V01B || version == EmotiBitVersion::V01C)
+	if (version < EmotiBitVersion::V02B)
 	{
 		HIBERNATE_PIN = 5;
 		SD_CARD_CHIP_SEL_PIN = 6;
 		_assignedPin[(int)EmotiBitPinName::EMOTIBIT_BUTTON] = 13;
+	}
+	else if (version <= EmotiBitVersion::V04A)
+	{
+	}
+	else if (version >= EmotiBitVersion::V05C)
+	{
+		_assignedPin[(int)EmotiBitPinName::PPG_INT] = 17;
+		_assignedPin[(int)EmotiBitPinName::ADS_RDY] = 15;
 	}
 	else
 	{
@@ -122,10 +133,20 @@ bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiB
 	_assignedPin[(int)EmotiBitPinName::BMI_INT1] = 14;
 	_assignedPin[(int)EmotiBitPinName::BMI_INT2] = 33;
 	_assignedPin[(int)EmotiBitPinName::BMM_INT] = 26;
+	_assignedPin[(int)EmotiBitPinName::ADS_RDY] = -1;
 
-	if (version == EmotiBitVersion::V02B || version == EmotiBitVersion::V02H || version == EmotiBitVersion::V03B || version == EmotiBitVersion::V04A)
+	if (version < EmotiBitVersion::V02B)
+	{
+		_assignedPin[(int)EmotiBitPinName::EMOTIBIT_BUTTON] = 13;
+	}
+	else if (version <= EmotiBitVersion::V04A)
 	{
 	}
+	else if (version >= EmotiBitVersion::V05C)
+	{
+		_assignedPin[(int)EmotiBitPinName::PPG_INT] = 39;
+		_assignedPin[(int)EmotiBitPinName::ADS_RDY] = 25;
+}
 	else
 	{
 		// unknown version

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -75,7 +75,10 @@ const char* EmotiBitVersionController::getHardwareVersion(EmotiBitVersion versio
 
 bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiBitVersion version)
 {
+	const bool checkLogic = false;
+	checkLogic ? Serial.println("initPinMapping:") : true;
 #if defined(ADAFRUIT_FEATHER_M0)
+	checkLogic ? Serial.println("ADAFRUIT_FEATHER_M0") : true;
 	// ToDo: Move these pin Assignments(maybe inside a constructor). These are specific to MCU platform and cannot change.
 	_assignedPin[(int)EmotiBitPinName::BATTERY_READ_PIN] = A7;
 	_assignedPin[(int)EmotiBitPinName::SPI_CLK] = 24;
@@ -89,17 +92,25 @@ bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiB
 	_assignedPin[(int)EmotiBitPinName::BMM_INT] = 14;
 	_assignedPin[(int)EmotiBitPinName::ADS_RDY] = -1;
 
-	if (version < EmotiBitVersion::V02B)
+	if (version == EmotiBitVersion::UNKNOWN)
 	{
+		checkLogic ? Serial.println("EmotiBitVersion::UNKNOWN") : true;
+		return true;
+	}
+	else if ((int)version < (int)EmotiBitVersion::V02B)
+	{
+		checkLogic ? Serial.println("v01") : true;
 		HIBERNATE_PIN = 5;
 		SD_CARD_CHIP_SEL_PIN = 6;
 		_assignedPin[(int)EmotiBitPinName::EMOTIBIT_BUTTON] = 13;
 	}
-	else if (version <= EmotiBitVersion::V04A)
+	else if ((int)version <= (int)EmotiBitVersion::V04A)
 	{
+		checkLogic ? Serial.println("v02-v04") : true;
 	}
-	else if (version >= EmotiBitVersion::V05C)
+	else if ((int)version >= (int)EmotiBitVersion::V05C)
 	{
+		checkLogic ? Serial.println("v05+") : true;
 		_assignedPin[(int)EmotiBitPinName::PPG_INT] = 17;
 		_assignedPin[(int)EmotiBitPinName::ADS_RDY] = 15;
 	}
@@ -110,8 +121,14 @@ bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiB
 		return false;
 	}
 #elif defined(ADAFRUIT_BLUEFRUIT_NRF52_FEATHER)
-	if (version == EmotiBitVersion::V01B || version == EmotiBitVersion::V01C)
+	if (version == EmotiBitVersion::UNKNOWN)
 	{
+		checkLogic ? Serial.println("EmotiBitVersion::UNKNOWN") : true;
+		return true;
+	}
+	else if ((int)version < (int)EmotiBitVersion::V02B)
+	{
+		checkLogic ? Serial.println("v01") : true;
 		HIBERNATE_PIN = 27;
 		_assignedPin[(int)EmotiBitPinName::EMOTIBIT_BUTTON] = 16;
 	}
@@ -122,6 +139,7 @@ bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiB
 		return false;
 	}
 #elif defined(ARDUINO_FEATHER_ESP32)
+	checkLogic ? Serial.println("ARDUINO_FEATHER_ESP32") : true;
 	// write the code here
 	_assignedPin[(int)EmotiBitPinName::BATTERY_READ_PIN] = A13;
 	_assignedPin[(int)EmotiBitPinName::SPI_CLK] = 5;
@@ -135,18 +153,26 @@ bool EmotiBitVersionController::initPinMapping(EmotiBitVersionController::EmotiB
 	_assignedPin[(int)EmotiBitPinName::BMM_INT] = 26;
 	_assignedPin[(int)EmotiBitPinName::ADS_RDY] = -1;
 
-	if (version < EmotiBitVersion::V02B)
+	if (version == EmotiBitVersion::UNKNOWN)
 	{
+		checkLogic ? Serial.println("EmotiBitVersion::UNKNOWN") : true;
+		return true;
+	}
+	else if ((int)version < (int)EmotiBitVersion::V02B)
+	{
+		checkLogic ? Serial.println("v01") : true;
 		_assignedPin[(int)EmotiBitPinName::EMOTIBIT_BUTTON] = 13;
 	}
-	else if (version <= EmotiBitVersion::V04A)
+	else if ((int)version <= (int)EmotiBitVersion::V04A)
 	{
+		checkLogic ? Serial.println("v02-v04") : true;
 	}
-	else if (version >= EmotiBitVersion::V05C)
+	else if ((int)version >= (int)EmotiBitVersion::V05C)
 	{
+		checkLogic ? Serial.println("v05+") : true;
 		_assignedPin[(int)EmotiBitPinName::PPG_INT] = 39;
 		_assignedPin[(int)EmotiBitPinName::ADS_RDY] = 25;
-}
+	}
 	else
 	{
 		// unknown version

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -5,6 +5,7 @@
 	@mainpage Controls reading Version from NVM on start or detecting version if NVM not updated, EmotiBit pin and constant asignment on startup
 	@section intro_sec Introduction
 	This is a library to handle EmotiBit HW version detection/version retrieval from NVM on setup.
+	See also "FW update instructions to support new HW version (EmotiBit).gdoc"
 	
 	EmotiBit invests time and resources providing this open source code,
 	please support EmotiBit and open-source hardware by purchasing
@@ -50,7 +51,8 @@ enum class EmotiBitPinName
 	BMI_INT2 = 7,
 	BMM_INT = 8,
 	BATTERY_READ_PIN = 9,
-	length = 10 //cannot be more than 28 (16 + 12)
+	ADS_RDY = 10,
+	length = 11 //cannot be more than 28 (16 + 12)
 };
 
 enum class MathConstants
@@ -102,6 +104,7 @@ public:
 		V02H = 4,
 		V03B = 5,
 		V04A = 6,
+		V05C = 7,
 		length
 	};
 


### PR DESCRIPTION
# Description
- Updated EmotiBitVersion, EmotiBitPinName, initPinMapping
- See `FW update instructions to support new HW version (EmotiBit).gdoc`

# Requirements
- none

# Issues Referenced
- none

# Documentation update
- none

# Testing
- ✅  M0: v02 finishes setup
- ✅ M0: v03 finishes setup
- ✅ M0: v04 finishes setup
- ❌ ESP32: v02 fails setup (known issue)
- ✅ ESP32: v03 finishes setup
- ✅ ESP32: v04 finishes setup
- ✅ v05c barcode on v04 HW read in factory test
  - ✅ streaming after factory test completed

**Test Configuration**:
* Firmware version:
* EmotiBit software version: v1.5.10
* EmotiBit Factory Test version: v1.3.5

# Checklist:
- [x] All dependent repositories used were on branch `master`
- [x] Release checklist completed (FW/ SW)
  - Make sure the required settings have been set to default before merging into master.
- [x] doxygen style comments included
- [x] Required documentation udpated

## Screenshots:
