### PR TITLE
Fixes version v05c to V05c

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -149,11 +149,15 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 				if (input == EmotiBitFactoryTest::MSG_START_CHAR)
 				{
 					String msg = Serial.readStringUntil(EmotiBitFactoryTest::MSG_TERM_CHAR);
+					Serial.print("Barcode msg: ");
+					Serial.println(msg);
 					String msgTypeTag = msg.substring(0, 2);
 					if (msgTypeTag.equals(EmotiBitFactoryTest::TypeTag::EMOTIBIT_BARCODE))
 					{
 						EmotiBitPacket::getPacketElement(msg, barcode.rawCode, 3);
 						barcodeReceived = true;
+						Serial.print("barcode.rawCode: ");
+						Serial.println(barcode.rawCode);
 					}
 					else
 					{
@@ -284,6 +288,14 @@ uint8_t EmotiBit::setup(size_t bufferCapacity)
 	{
 		// parse the barcode
 		EmotiBitFactoryTest::parseBarcode(&barcode);
+		Serial.print("barcode: ");
+		Serial.println(barcode.rawCode);
+		Serial.print("sku: ");
+		Serial.println(barcode.sku);
+		Serial.print("hwVersion: ");
+		Serial.println(barcode.hwVersion);
+		Serial.print("emotibitSerialNumber: ");
+		Serial.println(barcode.emotibitSerialNumber);
 
 		bool hwValidation, skuValidation = false;
 		if (emotiBitVersionController.validateBarcodeInfo(*(_EmotiBit_i2c), barcode, hwValidation, skuValidation))

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -49,7 +49,7 @@ public:
 	};
 
 
-  String firmware_version = "1.5.2";
+  String firmware_version = "1.5.2.fix-parseBarcode.0";
 
 
 	TestingMode testingMode = TestingMode::NONE;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -49,7 +49,7 @@ public:
 	};
 
 
-  String firmware_version = "1.5.2.fix-parseBarcode.0";
+  String firmware_version = "1.5.3";
 
 
 	TestingMode testingMode = TestingMode::NONE;

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -65,7 +65,7 @@ const char* EmotiBitVersionController::getHardwareVersion(EmotiBitVersion versio
 	}
 	else if (version == EmotiBitVersion::V05C)
 	{
-		return "v05c\0";
+		return "V05c\0";
 	}
 	else
 	{

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit FeatherWing
-version=1.5.2
+version=1.5.3
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A library written for EmotiBit FeatherWing that supports all sensors included on the wing.


### PR DESCRIPTION
# Description
Fixes problem with EmotiBitFactoryTest::convertBarcodeToVariantInfo() by conforming to uppercase V prefix

# Requirements
none

# Issues Referenced
none

# Documentation update
none

# Testing
Passes FactoryTest

# Checklist:
- [x] All dependent repositories used were on branch `master`
- [x] Release checklist completed (FW/ SW)
  - Make sure the required settings have been set to default before merging into master.
- [x] doxygen style comments included
- [x] Required documentation udpated

## Screenshots:
