### PR TITLE
fixed charlie plex example to reflect updated location and name of EmotiBit Emojis

### DIFF
--- a/examples/EmotiBit_examples/charlieplex_heartbeatOnSleeve/charlieplex_heartbeatOnSleeve.ino
+++ b/examples/EmotiBit_examples/charlieplex_heartbeatOnSleeve/charlieplex_heartbeatOnSleeve.ino
@@ -6,7 +6,7 @@ Working principle:
 filtered signal is used as a hreshold to light up the attached charlieplex.
 */
 #include "EmotiBit.h"
-#include "EmojiBit.h"
+#include "EmotiBitEmoji.h"
 #define SerialUSB SERIAL_PORT_USBVIRTUAL // Required to work in Visual Micro / Visual Studio IDE
 const uint32_t SERIAL_BAUD = 2000000; //115200
 
@@ -16,7 +16,7 @@ float data[dataSize];
 DigitalFilter filter_lp2(DigitalFilter::FilterType::IIR_LOWPASS, 25, 0.075);
 
 // Initializing Charlieplex wing
-EmojiBit matrix = EmojiBit();
+EmotibitEmoji matrix = EmotibitEmoji();
 
 void onShortButtonPress()
 {

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit FeatherWing
-version=1.5.4
+version=1.5.5
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A library written for EmotiBit FeatherWing that supports all sensors included on the wing.
@@ -7,4 +7,4 @@ paragraph= Requires dependent libraries as shown in the getting started document
 category=Sensors
 url=https://github.com/EmotiBit/EmotiBit_FeatherWing
 architectures=*
-depends=EmotiBit BMI160, EmotiBit MAX30101, EmotiBit MLX90632, EmotiBit NCP5623, EmotiBit SI7013, EmotiBit XPlat Utils, EmotiBit ADS1X15, EmotiBit External EEPROM
+depends=EmotiBit BMI160, EmotiBit MAX30101, EmotiBit MLX90632, EmotiBit NCP5623, EmotiBit SI7013, EmotiBit XPlat Utils, EmotiBit ADS1X15, EmotiBit External EEPROM, EmotiBit EmojiLib


### PR DESCRIPTION
# Description
- updated `library.properties` and fixed charlieplex example to use updated Emoji library name and location

# Requirements
- https://github.com/EmotiBit/EmotiBit_EmojiLib


# Issues Referenced
<!-- If Any -->
- Fixes #186 

# Documentation update
- https://github.com/EmotiBit/EmotiBit_Docs/pull/105#discussion_r1101994979

# Testing
- Compiles ✔️ 


# Checklist:
- [ ] All dependent repositories used were on branch `master`
- [ ] Release checklist completed (FW/ SW)
  - Make sure the required settings have been set to default before merging into master.
- [ ] doxygen style comments included
- [ ] Required documentation udpated

## Screenshots:
