### PR TITLE
Added fix for long wait between connections on Adafruit feather m0

### DIFF
--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.7.0";
+  String firmware_version = "1.7.0.hotfix-wifiConnectionAttemptDelay";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.7.0.hotfix-wifiConnectionAttemptDelay";
+  String firmware_version = "1.7.1";
 
 
 

--- a/EmotiBitWiFi.cpp
+++ b/EmotiBitWiFi.cpp
@@ -135,8 +135,13 @@ uint8_t EmotiBitWiFi::begin(const Credential credential, uint8_t maxAttempts, ui
 		Serial.println(millis() - beginDuration);
 		wifiStatus = status();
 		_needsAdvertisingBegin = true;
-		//while((wifiStatus == WL_IDLE_STATUS) && (millis() - beginDuration < attemptDelay)) // This is necessary for ESP32 unless callback is utilized
-    while((wifiStatus == WL_IDLE_STATUS || wifiStatus == WL_DISCONNECTED) && (millis() - beginDuration < attemptDelay)) // This is necessary for ESP32 unless callback is utilized
+		bool checkForDisconnected = false;  //< Boolean to control behaviour of connection status check.
+#ifdef ARDUINO_FEATHER_ESP32
+		checkForDisconnected = true;
+#endif
+		// only check for WL_DISCONNECTED if board is ESP. It is because of how WiFi library on ESP handles a connection failure.
+		// ToDo: reconsider this logic if support for new board (apart from M0 or ESP32) is added
+    	while((wifiStatus == WL_IDLE_STATUS || (checkForDisconnected && wifiStatus == WL_DISCONNECTED)) && (millis() - beginDuration < attemptDelay)) // This is necessary for ESP32 unless callback is utilized
 		{
 			delay(attemptDelay / 10);
 			wifiStatus = status();

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit FeatherWing
-version=1.7.0
+version=1.7.1
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A library written for EmotiBit FeatherWing that supports all sensors included on the wing.


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
Fixes a bug where network switching on feather M0 would take [`attemptDelay`](https://github.com/EmotiBit/EmotiBit_FeatherWing/blob/2c7cc6fcbf87d8d04421964b404c9685f8882b59/EmotiBit.cpp#L951) (set in code) seconds. This artifact was introduced when changes were made to support enterprise wifi on ESP32.

This bug caused the Feather M0 to wait for 20 secs before switching networks (even if the network it was trying to connect to was not available).
This patch fixes that issue and now, if a network is not available (Feather M0 fails to connect to it), it moves on to the next network.

# Requirements
- None


# Issues Referenced
<!-- If Any -->
- None

# Documentation update
- None

# Testing
The following shows the setup log indicating time taken between trying separate networks.

- Testing on ESP32 (**SSID not available**)
  - Notice that even though the timeout is set to 20secs, it switches to the next network after 4 secs (time taken for ESP to detect absence of network)
  - WiFi.status() = 1 is `WL_NO_SSID_AVAIL`
```
ttempting to connect to SSID: brainwaves2.4
WiFi.begin() duration = 116
WiFi.status() = 1, total duration = 4116
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: emotinet
WiFi.begin() duration = 116
WiFi.status() = 1, total duration = 4116
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: brainwaves2.4
WiFi.begin() duration = 116
WiFi.status() = 1, total duration = 4117
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: emotinet
WiFi.begin() duration = 116
WiFi.status() = 1, total duration = 4116
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: brainwaves2.4
WiFi.begin() duration = 117
WiFi.status() = 1, total duration = 4117
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: emotinet
WiFi.begin() duration = 117
WiFi.status() = 1, total duration = 4117
```

- Testing on ESP32 (**SSID available**)
```
Attempting to connect to SSID: emotinet
WiFi.begin() duration = 72
WiFi.status() = 1, total duration = 4073
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: FiOS-RUV
WiFi.begin() duration = 125
WiFi.status() = 3, total duration = 6124
WiFi.begin() attempts = 2
Connected to WiFi
SSID: FiOS-RUV
```

- Testing  on Feather M0 (**SSID not available**)
  - Notice that the Feather switches network as soon as it fails to connect to the network it is trying.
  - The bug caused the Feather to wait here for 20 secs. Now it moves to the next network within 1 second.
  - WiFi.status() = 6 is `WL_DISCONNECTED`
```
Attempting to connect to SSID: brainwaves2.4
WiFi.begin() duration = 952
WiFi.status() = 6, total duration = 952
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: emotinet
WiFi.begin() duration = 920
WiFi.status() = 6, total duration = 921
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: brainwaves2.4
WiFi.begin() duration = 921
WiFi.status() = 6, total duration = 921
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: emotinet
WiFi.begin() duration = 921
WiFi.status() = 6, total duration = 921
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: brainwaves2.4
WiFi.begin() duration = 920
WiFi.status() = 6, total duration = 921
```

- Testing  on Feather M0 (**SSID available**)
```
Attempting to connect to SSID: emotinet
WiFi.begin() duration = 952
WiFi.status() = 6, total duration = 952
<<<<<<< Switching WiFi Networks >>>>>>>
Attempting to connect to SSID: FiOS-RU
WiFi.begin() duration = 1033
WiFi.status() = 3, total duration = 1034
WiFi.begin() attempts = 2
Connected to WiFi
SSID: FiOS-RUV
IP Address: 192.168.1.84
```


## Steps to test
- Flash the EmotiBit with the bin files. [1.7.0.hotfix-wifiConnectionAttemptDelay.zip](https://github.com/EmotiBit/EmotiBit_FeatherWing/files/11165003/1.7.0.hotfix-wifiConnectionAttemptDelay.zip)
- Add credentials to an SSID that does not exist/ is not currently available.
- Notice the switching speed in the serial log.
- It should switch networks faster than 20 secs (which is the current programmed delay)

# Checklist to allow merge
- [x] All dependent repositories used were on branch `master`
- Firmware
  - [x] Set testingMode to TestingMode::NONE
  - [x] Set const bool `DIGITAL_WRITE_DEBUG` = false (if set true while testing)
  - [x] Update version in EmotiBit.h
  - [x] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] Update software bundle version in `ofxEmotiBitVersion.h`
- [x] doxygen style comments included for new code snippets
- [ ] Required documentation updated

## Screenshots:
