### PR TITLE
Updated from ArduinoJson 5 to latest.

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -3510,25 +3510,13 @@ bool EmotiBit::loadConfigFile(const String &filename) {
 	Serial.print("Number of network credentials found in config file: ");
 	Serial.println(configSize);
 	for (size_t i = 0; i < configSize; i++) {
-		String ssid = jsonDoc["WifiCredentials"][i]["ssid"].as<String>();
-		String userid = jsonDoc["WifiCredentials"][i]["userid"].as<String>();
-		String username = jsonDoc["WifiCredentials"][i]["username"].as<String>();
-		String pass = jsonDoc["WifiCredentials"][i]["password"].as<String>();
+		String ssid = jsonDoc["WifiCredentials"][i]["ssid"] | "";  // See implementation example: https://arduinojson.org/v6/api/jsonvariant/or/
+		String userid = jsonDoc["WifiCredentials"][i]["userid"] | "";
+		String username = jsonDoc["WifiCredentials"][i]["username"] | "";
+		String pass = jsonDoc["WifiCredentials"][i]["password"] | "";
+
 		Serial.print("Adding SSID: ");
 		Serial.print(ssid);
-
-		if (ssid.equals("null")){
-			ssid="";
-		}
-		if (userid.equals("null")){
-			userid="";
-		}
-		if (username.equals("null")){
-			username="";
-		}
-		if (pass.equals("null")){
-			pass="";
-		}
 
 		if (!userid.equals(""))
 		{
@@ -3539,6 +3527,7 @@ bool EmotiBit::loadConfigFile(const String &filename) {
 			}
 		}
 		Serial.print(" -pass:" + pass);
+		
 		if (_emotiBitWiFi.addCredential(ssid, userid, username, pass) < 0)
 		{
 			// Number of credentials exceeded max allowed
@@ -3549,11 +3538,11 @@ bool EmotiBit::loadConfigFile(const String &filename) {
 		}
 		else
 		{
-			Serial.println("... success");
+			Serial.println(" ... success");
 		}
-		_emotiBitWiFi.setDeviceId(emotibitDeviceId);
 
 	}
+	_emotiBitWiFi.setDeviceId(emotibitDeviceId);
 
 	//strlcpy(config.hostname,                   // <- destination
 	//	root["hostname"] | "example.com",  // <- source

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -2538,149 +2538,132 @@ bool EmotiBit::printConfigInfo(File &file, const String &datetimeString) {
 
 	{
 		// Write basic EmotiBit info
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		const uint8_t nInfo = 1;
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
-		infos[i]->set("name", "EmotiBitData");
-		infos[i]->set("type", "Multimodal");
-		infos[i]->set("source_id", _sourceId);
-		infos[i]->set("hardware_version", hardware_version);
-		infos[i]->set("sku", emotiBitSku);
-		infos[i]->set("device_id", emotibitDeviceId);
-		infos[i]->set("feather_version", _featherVersion);
-		infos[i]->set("feather_wifi_mac_addr", getFeatherMacAddress());
-		infos[i]->set("firmware_version", firmware_version);
-		infos[i]->set("firmware_variant", firmware_variant);
-		infos[i]->set("created_at", datetimeString);
-		if (root.printTo(file) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i] = root.createNestedObject("info");
+		infos[i]["name"] = "EmotiBitData";
+		infos[i]["type"] = "Multimodal";
+		infos[i]["source_id"] = _sourceId;
+		infos[i]["hardware_version"] = hardware_version;
+		infos[i]["sku"] = emotiBitSku;
+		infos[i]["device_id"] = emotibitDeviceId;
+		infos[i]["feather_version"] = _featherVersion;
+		infos[i]["feather_wifi_mac_addr"] = getFeatherMacAddress();
+		infos[i]["firmware_version"] = firmware_version;
+		infos[i]["firmware_variant"] = firmware_variant;
+		infos[i]["created_at"] = datetimeString;
+		serializeJson(jsonDoc, file);
 	}
 
 	file.print(","); // Doing some manual printing to chunk JSON and save RAM
 
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		//JsonArray& root = jsonBuffer.createArray();
 		const uint8_t nInfo = 1;
 		//JsonObject* indices[nInfo];
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
+		infos[i] = root.createNestedObject("info");
 
 		// ToDo: Use EmotiBitPacket::TypeTag rather than fallable constants to set typeTags
 
 		// Accelerometer
 		//indices[i] = &(root.createNestedObject());
 		//infos[i] = &(indices[i]->createNestedObject("info"));
-		infos[i]->set("name", "Accelerometer");
-		infos[i]->set("type", "Accelerometer");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add("AX");
-		typeTags[i]->add("AY");
-		typeTags[i]->add("AZ");
-		infos[i]->set("channel_count", 3);
-		infos[i]->set("nominal_srate", _samplingRates.accelerometer);
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "g");
-		setups[i] = &(infos[i]->createNestedObject("setup"));
-		setups[i]->set("range", _accelerometerRange);
-		setups[i]->set("acc_bwp", imuSettings.acc_bwp);
-		setups[i]->set("acc_us", imuSettings.acc_us);
-
-		if (root.printTo(file) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i]["name"] = "Accelerometer";
+		infos[i]["type"] = "Accelerometer";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add("AX");
+		typeTags[i].add("AY");
+		typeTags[i].add("AZ");
+		infos[i]["channel_count"] = 3;
+		infos[i]["nominal_srate"] = _samplingRates.accelerometer;
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "g";
+		setups[i] = infos[i].createNestedObject("setup");
+		setups[i]["range"] = _accelerometerRange;
+		setups[i]["acc_bwp"] = imuSettings.acc_bwp;
+		setups[i]["acc_us"] = imuSettings.acc_us;
+		serializeJson(jsonDoc, file);
 	}
 
 	file.print(","); // Doing some manual printing to chunk JSON and save RAM
 
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		//JsonArray& root = jsonBuffer.createArray();
 		const uint8_t nInfo = 1;
 		//JsonObject* indices[nInfo];
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
+		infos[i] = root.createNestedObject("info");
 
 		// Gyroscope
 		//i++;
 		//indices[i] = &(root.createNestedObject());
 		//infos[i] = &(indices[i]->createNestedObject("info"));
-		infos[i]->set("name", "Gyroscope");
-		infos[i]->set("type", "Gyroscope");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add("GX");
-		typeTags[i]->add("GY");
-		typeTags[i]->add("GZ");
-		infos[i]->set("channel_count", 3);
-		infos[i]->set("nominal_srate", _samplingRates.gyroscope);
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "degrees/second");
-		setups[i] = &(infos[i]->createNestedObject("setup"));
-		setups[i]->set("range", _gyroRange);
-		setups[i]->set("gyr_bwp", imuSettings.gyr_bwp);
-		setups[i]->set("gyr_us", imuSettings.gyr_us);
-		if (root.printTo(file) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i]["name"] = "Gyroscope";
+		infos[i]["type"] = "Gyroscope";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add("GX");
+		typeTags[i].add("GY");
+		typeTags[i].add("GZ");
+		infos[i]["channel_count"] = 3;
+		infos[i]["nominal_srate"] = _samplingRates.gyroscope;
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "degrees/second";
+		setups[i] = infos[i].createNestedObject("setup");
+		setups[i]["range"] = _gyroRange;
+		setups[i]["gyr_bwp"] = imuSettings.gyr_bwp;
+		setups[i]["gyr_us"] = imuSettings.gyr_us;
+		serializeJson(jsonDoc, file);
 	}
 
 	file.print(","); // Doing some manual printing to chunk JSON and save RAM
 
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		//JsonArray& root = jsonBuffer.createArray();
 		const uint8_t nInfo = 1;
 		//JsonObject* indices[nInfo];
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
+		infos[i] = root.createNestedObject("info");
 
 		// Magnetometer
 		//i++;
 		//indices[i] = &(root.createNestedObject());
 		//infos[i] = &(indices[i]->createNestedObject("info"));
-		infos[i]->set("name", "Magnetometer");
-		infos[i]->set("type", "Magnetometer");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add("MX");
-		typeTags[i]->add("MY");
-		typeTags[i]->add("MZ");
-		infos[i]->set("channel_count", 3);
-		infos[i]->set("nominal_srate", _samplingRates.magnetometer);
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "microhenries");
-		setups[i] = &(infos[i]->createNestedObject("setup"));
-		if (root.printTo(file) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i]["name"] = "Magnetometer";
+		infos[i]["type"] = "Magnetometer";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add("MX");
+		typeTags[i].add("MY");
+		typeTags[i].add("MZ");
+		infos[i]["channel_count"] = 3;
+		infos[i]["nominal_srate"] = _samplingRates.magnetometer;
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "microhenries";
+		setups[i] = infos[i].createNestedObject("setup");
+		serializeJson(jsonDoc, file);
 	}
 
 	file.print(","); // Doing some manual printing to chunk JSON and save RAM
@@ -2693,260 +2676,232 @@ bool EmotiBit::printConfigInfo(File &file, const String &datetimeString) {
 	{
 		{
 			// Parse the root object
-			StaticJsonBuffer<bufferSize> jsonBuffer;
-			JsonObject &root = jsonBuffer.createObject();
+			StaticJsonDocument<bufferSize> jsonDoc;
+			JsonObject root = jsonDoc.to<JsonObject>();
 			//JsonArray& root = jsonBuffer.createArray();
 			const uint8_t nInfo = 1;
 			//JsonObject* indices[nInfo];
-			JsonObject* infos[nInfo];
-			JsonArray* typeTags[nInfo];
-			JsonObject* setups[nInfo];
+			JsonObject infos[nInfo];
+			JsonArray typeTags[nInfo];
+			JsonObject setups[nInfo];
 			uint8_t i = 0;
-			infos[i] = &(root.createNestedObject("info"));
+			infos[i] = root.createNestedObject("info");
 			// Humidity0
 			//i++;
 			//indices[i] = &(root.createNestedObject());
 			//infos[i] = &(indices[i]->createNestedObject("info"));
-			infos[i]->set("name", "Humidity0");
-			infos[i]->set("type", "Humidity");
-			typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-			typeTags[i]->add("H0");
-			infos[i]->set("channel_count", 1);
-			infos[i]->set("nominal_srate", _samplingRates.humidity / _samplesAveraged.humidity);
-			infos[i]->set("channel_format", "float");
-			infos[i]->set("units", "Percent");
-			setups[i] = &(infos[i]->createNestedObject("setup"));
-			setups[i]->set("resolution", "RESOLUTION_H11_T11");
-			setups[i]->set("samples_averaged", _samplesAveraged.humidity);
-			setups[i]->set("oversampling_rate", _samplingRates.humidity);
-			if (root.printTo(file) == 0) {
-#ifdef DEBUG
-				Serial.println(F("Failed to write to file"));
-#endif
-			}
+			infos[i]["name"] = "Humidity0";
+			infos[i]["type"] = "Humidity";
+			typeTags[i] = infos[i].createNestedArray("typeTags");
+			typeTags[i].add("H0");
+			infos[i]["channel_count"] = 1;
+			infos[i]["nominal_srate"] = _samplingRates.humidity / _samplesAveraged.humidity;
+			infos[i]["channel_format"] = "float";
+			infos[i]["units"] = "Percent";
+			setups[i] = infos[i].createNestedObject("setup");
+			setups[i]["resolution"] = "RESOLUTION_H11_T11";
+			setups[i]["samples_averaged"] = _samplesAveraged.humidity;
+			setups[i]["oversampling_rate"] = _samplingRates.humidity;
+			serializeJson(jsonDoc, file);
 		}
 
 		file.print(","); // Doing some manual printing to chunk JSON and save RAM
 
 		{
 			// Parse the root object
-			StaticJsonBuffer<bufferSize> jsonBuffer;
-			JsonObject &root = jsonBuffer.createObject();
+			StaticJsonDocument<bufferSize> jsonDoc;
+			JsonObject root = jsonDoc.to<JsonObject>();
 			//JsonArray& root = jsonBuffer.createArray();
 			const uint8_t nInfo = 1;
 			//JsonObject* indices[nInfo];
-			JsonObject* infos[nInfo];
-			JsonArray* typeTags[nInfo];
-			JsonObject* setups[nInfo];
+			JsonObject infos[nInfo];
+			JsonArray typeTags[nInfo];
+			JsonObject setups[nInfo];
 			uint8_t i = 0;
-			infos[i] = &(root.createNestedObject("info"));
+			infos[i] = root.createNestedObject("info");
 			// Temperature0
 			//i++;
 			//indices[i] = &(root.createNestedObject());
 			//infos[i] = &(indices[i]->createNestedObject("info"));
-			infos[i]->set("name", "Temperature0");
-			infos[i]->set("type", "Temperature");
-			typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-			typeTags[i]->add("T0");
-			infos[i]->set("channel_count", 1);
-			infos[i]->set("nominal_srate", _samplingRates.temperature / _samplesAveraged.temperature);
-			infos[i]->set("channel_format", "float");
-			infos[i]->set("units", "degrees celcius");
-			infos[i]->set("sensor_part_number", "Si7013");
-			infos[i]->set("sensor_serial_number_a", tempHumiditySensor.sernum_a);
-			infos[i]->set("sensor_serial_number_b", tempHumiditySensor.sernum_b);
-			setups[i] = &(infos[i]->createNestedObject("setup"));
-			setups[i]->set("resolution", "RESOLUTION_H11_T11");
-			setups[i]->set("samples_averaged", _samplesAveraged.temperature);
-			setups[i]->set("oversampling_rate", _samplingRates.temperature);
-			if (root.printTo(file) == 0) {
-#ifdef DEBUG
-				Serial.println(F("Failed to write to file"));
-#endif
-			}
+			infos[i]["name"] = "Temperature0";
+			infos[i]["type"] = "Temperature";
+			typeTags[i] = infos[i].createNestedArray("typeTags");
+			typeTags[i].add("T0");
+			infos[i]["channel_count"] = 1;
+			infos[i]["nominal_srate"] = _samplingRates.temperature / _samplesAveraged.temperature;
+			infos[i]["channel_format"] = "float";
+			infos[i]["units"] = "degrees celcius";
+			infos[i]["sensor_part_number"] = "Si7013";
+			infos[i]["sensor_serial_number_a"] = tempHumiditySensor.sernum_a;
+			infos[i]["sensor_serial_number_b"] = tempHumiditySensor.sernum_b;
+			setups[i] = infos[i].createNestedObject("setup");
+			setups[i]["resolution"] = "RESOLUTION_H11_T11";
+			setups[i]["samples_averaged"] = _samplesAveraged.temperature;
+			setups[i]["oversampling_rate"] = _samplingRates.temperature;
+			serializeJson(jsonDoc, file);
 		}
 		file.print(","); // Doing some manual printing to chunk JSON and save RAM
 	}
 	
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		//JsonArray& root = jsonBuffer.createArray();
 		const uint8_t nInfo = 1;
 		//JsonObject* indices[nInfo];
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
+		infos[i] = root.createNestedObject("info");
 		// Temperature0
 		//i++;
 		//indices[i] = &(root.createNestedObject());
 		//infos[i] = &(indices[i]->createNestedObject("info"));
-		infos[i]->set("name", "Temperature1");
-		infos[i]->set("type", "Temperature");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add("T1");
-		infos[i]->set("channel_count", 1);
-		infos[i]->set("nominal_srate", _samplingRates.temperature_1 / _samplesAveraged.temperature_1);
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "degrees celcius");
-		infos[i]->set("sensor_part_number", "MAX30101");
-		setups[i] = &(infos[i]->createNestedObject("setup"));
-		setups[i]->set("samples_averaged", _samplesAveraged.temperature_1);
-		setups[i]->set("oversampling_rate", _samplingRates.temperature_1);
-		if (root.printTo(file) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i]["name"] = "Temperature1";
+		infos[i]["type"] = "Temperature";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add("T1");
+		infos[i]["channel_count"] = 1;
+		infos[i]["nominal_srate"] = _samplingRates.temperature_1 / _samplesAveraged.temperature_1;
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "degrees celcius";
+		infos[i]["sensor_part_number"] = "MAX30101";
+		setups[i] = infos[i].createNestedObject("setup");
+		setups[i]["samples_averaged"] = _samplesAveraged.temperature_1;
+		setups[i]["oversampling_rate"] = _samplingRates.temperature_1;
+		serializeJson(jsonDoc, file);
 	}
 	
 	file.print(","); // Doing some manual printing to chunk JSON and save RAM
 
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		//JsonArray& root = jsonBuffer.createArray();
 		const uint8_t nInfo = 1;
 		//JsonObject* indices[nInfo];
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
+		infos[i] = root.createNestedObject("info");
 
 		// thermopile
 		//i++;
 		//indices[i] = &(root.createNestedObject());
 		//infos[i] = &(indices[i]->createNestedObject("info"));
-		infos[i]->set("name", "Thermopile");
-		infos[i]->set("type", "Temperature");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add("TH");
-		infos[i]->set("channel_count", 1);
+		infos[i]["name"] = "Thermopile";
+		infos[i]["type"] = "Temperature";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add("TH");
+		infos[i]["channel_count"] = 1;
 		if (thermopileMode == MODE_CONTINUOUS)
 		{
-			infos[i]->set("nominal_srate", thermopileFs);
+			infos[i]["nominal_srate"] = thermopileFs;
 		}
 		else
 		{
-			infos[i]->set("nominal_srate", _samplingRates.thermopile / _samplesAveraged.thermopile);
+			infos[i]["nominal_srate"] = _samplingRates.thermopile / _samplesAveraged.thermopile;
 		}
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "degrees celcius");
-		setups[i] = &(infos[i]->createNestedObject("setup"));
-		setups[i]->set("samples_averaged", _samplesAveraged.thermopile);
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "degrees celcius";
+		setups[i] = infos[i].createNestedObject("setup");
+		setups[i]["samples_averaged"] = _samplesAveraged.thermopile;
 		if (thermopileMode == MODE_CONTINUOUS)
 		{
-			infos[i]->set("oversampling_rate", thermopileFs);
+			infos[i]["oversampling_rate"] = thermopileFs;
 		}
 		else
 		{
-			setups[i]->set("oversampling_rate", _samplingRates.thermopile);
+			setups[i]["oversampling_rate"] = _samplingRates.thermopile;
 		}
-		if (root.printTo(file) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		serializeJson(jsonDoc, file);
 	}
 
 	file.print(","); // Doing some manual printing to chunk JSON and save RAM
 
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		//JsonArray& root = jsonBuffer.createArray();
 		const uint8_t nInfo = 1;
 		//JsonObject* indices[nInfo];
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
+		infos[i] = root.createNestedObject("info");
 
 		// PPG
 		//i++;
 		//indices[i] = &(root.createNestedObject());
 		//infos[i] = &(indices[i]->createNestedObject("info"));
-		infos[i]->set("name", "PPG");
-		infos[i]->set("type", "PPG");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add("PI");
-		typeTags[i]->add("PR");
-		typeTags[i]->add("PG");
-		infos[i]->set("channel_count", 3);
-		infos[i]->set("nominal_srate", ppgSettings.sampleRate / ppgSettings.sampleAverage);
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "raw units");
-		setups[i] = &(infos[i]->createNestedObject("setup"));
-		setups[i]->set("LED_power_level", ppgSettings.ledPowerLevel);
-		setups[i]->set("samples_averaged", ppgSettings.sampleAverage);
-		setups[i]->set("LED_mode", ppgSettings.ledMode);
-		setups[i]->set("oversampling_rate", ppgSettings.sampleRate);
-		setups[i]->set("pulse_width", ppgSettings.pulseWidth);
-		setups[i]->set("ADC_range", ppgSettings.adcRange);
-		if (root.printTo(file) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i]["name"] = "PPG";
+		infos[i]["type"] = "PPG";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add("PI");
+		typeTags[i].add("PR");
+		typeTags[i].add("PG");
+		infos[i]["channel_count"] = 3;
+		infos[i]["nominal_srate"] = ppgSettings.sampleRate / ppgSettings.sampleAverage;
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "raw units";
+		setups[i] = infos[i].createNestedObject("setup");
+		setups[i]["LED_power_level"] = ppgSettings.ledPowerLevel;
+		setups[i]["samples_averaged"] = ppgSettings.sampleAverage;
+		setups[i]["LED_mode"] = ppgSettings.ledMode;
+		setups[i]["oversampling_rate"] = ppgSettings.sampleRate;
+		setups[i]["pulse_width"] = ppgSettings.pulseWidth;
+		setups[i]["ADC_range"] = ppgSettings.adcRange;
+		serializeJson(jsonDoc, file);
 	}
 
 	file.print(","); // Doing some manual printing to chunk JSON and save RAM
 	// Heart Rate
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		const uint8_t nInfo = 1;
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
-		infos[i]->set("name", "HeartRate");
-		infos[i]->set("type", "PPG");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add(EmotiBitPacket::TypeTag::HEART_RATE);
-		infos[i]->set("channel_count", 1);
-		infos[i]->set("channel_format", "int");
-		infos[i]->set("units", "bpm");
-		if (root.printTo(file) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i] = root.createNestedObject("info");
+		infos[i]["name"] = "HeartRate";
+		infos[i]["type"] = "PPG";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add(EmotiBitPacket::TypeTag::HEART_RATE);
+		infos[i]["channel_count"] = 1;
+		infos[i]["channel_format"] = "int";
+		infos[i]["units"] = "bpm";
+		serializeJson(jsonDoc, file);
 	}
 
 	file.print(","); // Doing some manual printing to chunk JSON and save RAM
 	// interBeat interval
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		const uint8_t nInfo = 1;
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
-		infos[i]->set("name", "InterBeatInterval");
-		infos[i]->set("type", "PPG");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add(EmotiBitPacket::TypeTag::INTER_BEAT_INTERVAL);
-		infos[i]->set("channel_count", 1);
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "mS");
-		if (root.printTo(file) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i] = root.createNestedObject("info");
+		infos[i]["name"] = "InterBeatInterval";
+		infos[i]["type"] = "PPG";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add(EmotiBitPacket::TypeTag::INTER_BEAT_INTERVAL);
+		infos[i]["channel_count"] = 1;
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "mS";
+		serializeJson(jsonDoc, file);
 	}
 	file.print("]"); // Doing some manual printing to chunk JSON and save RAM
 
@@ -3538,12 +3493,12 @@ bool EmotiBit::loadConfigFile(const String &filename) {
 	// Don't forget to change the capacity to match your JSON document.
 	// Use arduinojson.org/assistant to compute the capacity.
 	//StaticJsonBuffer<1024> jsonBuffer;
-	StaticJsonBuffer<1024> jsonBuffer;
+	StaticJsonDocument<1024> jsonDoc;
 
 	// Parse the root object
-	JsonObject &root = jsonBuffer.parseObject(file);
+	DeserializationError error = deserializeJson(jsonDoc, file);
 
-	if (!root.success()) {
+	if (error) {
 		Serial.println(F("Failed to parse config file"));
 		setupFailed("Failed to parse Config file contents");
 		return false;
@@ -3551,16 +3506,30 @@ bool EmotiBit::loadConfigFile(const String &filename) {
 
 	size_t configSize;
 	// Copy values from the JsonObject to the Config
-	configSize = root.get<JsonVariant>("WifiCredentials").as<JsonArray>().size();
+	configSize = jsonDoc["WifiCredentials"].size(); 
 	Serial.print("Number of network credentials found in config file: ");
 	Serial.println(configSize);
 	for (size_t i = 0; i < configSize; i++) {
-		String ssid = root["WifiCredentials"][i]["ssid"] | "";
-		String userid = root["WifiCredentials"][i]["userid"] | "";
-		String username = root["WifiCredentials"][i]["username"] | "";
-		String pass = root["WifiCredentials"][i]["password"] | "";
+		String ssid = jsonDoc["WifiCredentials"][i]["ssid"].as<String>();
+		String userid = jsonDoc["WifiCredentials"][i]["userid"];
+		String username = jsonDoc["WifiCredentials"][i]["username"].as<String>();
+		String pass = jsonDoc["WifiCredentials"][i]["password"].as<String>();
 		Serial.print("Adding SSID: ");
-		Serial.print(ssid); 
+		Serial.print(ssid);
+
+		if (ssid.equals("null")){
+			ssid="";
+		}
+		if (userid.equals("null")){
+			userid="";
+		}
+		if (username.equals("null")){
+			username="";
+		}
+		if (pass.equals("null")){
+			pass="";
+		}
+
 		if (!userid.equals(""))
 		{
 			Serial.print(" -userid:"); Serial.print(userid);
@@ -4600,7 +4569,13 @@ void EmotiBit::printEmotiBitInfo()
   Serial.print("\"firmware_variant\":\"");
 	Serial.print(firmware_variant);
 	Serial.println("\",");
-  
+
+#ifdef ADAFRUIT_FEATHER_M0
+	Serial.print("\"free_memory\":\"");
+	Serial.print(String(freeMemory(), DEC));
+	Serial.println("\",");
+#endif
+
   if (_emotiBitWiFi.status() == WL_CONNECTED)
   {
     IPAddress ip = WiFi.localIP();

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -3511,7 +3511,7 @@ bool EmotiBit::loadConfigFile(const String &filename) {
 	Serial.println(configSize);
 	for (size_t i = 0; i < configSize; i++) {
 		String ssid = jsonDoc["WifiCredentials"][i]["ssid"].as<String>();
-		String userid = jsonDoc["WifiCredentials"][i]["userid"];
+		String userid = jsonDoc["WifiCredentials"][i]["userid"].as<String>();
 		String username = jsonDoc["WifiCredentials"][i]["username"].as<String>();
 		String pass = jsonDoc["WifiCredentials"][i]["password"].as<String>();
 		Serial.print("Adding SSID: ");

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.9.1";
+  String firmware_version = "1.9.0";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.8.1.fix-JsonLibUpdate.1";
+  String firmware_version = "1.8.1.fix-JsonLibUpdate.2";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.8.1.fix-JsonLibUpdate.2";
+  String firmware_version = "2.0.0";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.8.1";
+  String firmware_version = "2.0.0";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "2.0.0";
+  String firmware_version = "1.8.1.fix-JsonLibUpdate.1";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "2.0.0";
+  String firmware_version = "1.9.1";
 
 
 

--- a/EmotiBitEda.cpp
+++ b/EmotiBitEda.cpp
@@ -525,125 +525,109 @@ bool EmotiBitEda::writeInfoJson(File &jsonFile)
 	const uint16_t bufferSize = 1024;
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		const uint8_t nInfo = 1;
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
-		infos[i]->set("name", "ElectrodermalActivity");
-		infos[i]->set("type", "ElectrodermalActivity");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add("EA");
-		infos[i]->set("channel_count", 1);
-		infos[i]->set("nominal_srate", _constants.samplingRate);
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "microsiemens");
-		setups[i] = &(infos[i]->createNestedObject("setup"));
-		setups[i]->set("eda_series_resistance", _constants.edaSeriesResistance);
-		setups[i]->set("adc_bits", _constants.adcBits);
-		setups[i]->set("enable_digital_filter", _constants.enableDigitalFilter);
-		setups[i]->set("samples_averaged", _edlOversampBuffer->capacity());
-		setups[i]->set("oversampling_rate", _edlOversampBuffer->capacity() * _constants.samplingRate);
+		infos[i] = root.createNestedObject("info");
+		infos[i]["name"] = "ElectrodermalActivity";
+		infos[i]["type"] = "ElectrodermalActivity";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add("EA");
+		infos[i]["channel_count"] = 1;
+		infos[i]["nominal_srate"] = _constants.samplingRate;
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "microsiemens";
+		setups[i] = infos[i].createNestedObject("setup");
+		setups[i]["eda_series_resistance"] = _constants.edaSeriesResistance;
+		setups[i]["adc_bits"] = _constants.adcBits;
+		setups[i]["enable_digital_filter"] = _constants.enableDigitalFilter;
+		setups[i]["samples_averaged"] = _edlOversampBuffer->capacity();
+		setups[i]["oversampling_rate"] = _edlOversampBuffer->capacity() * _constants.samplingRate;
 		if (_emotibitVersion >= EmotiBitVersionController::EmotiBitVersion::V04A)
 		{
-			setups[i]->set("eda_transform_slope", _constants_v4_plus.edaTransformSlope);
-			setups[i]->set("eda_transform_intercept", _constants_v4_plus.edaTransformIntercept);
+			setups[i]["eda_transform_slope"] = _constants_v4_plus.edaTransformSlope;
+			setups[i]["eda_transform_intercept"] = _constants_v4_plus.edaTransformIntercept;
 		} 
 		else
 		{
-			setups[i]->set("voltage_reference_1", _constants_v2_v3.vRef1);
-			setups[i]->set("voltage_reference_2", _constants_v2_v3.vRef2);
-			setups[i]->set("EDA_feedback_amp_resistance", _constants_v2_v3.feedbackAmpR);
-			setups[i]->set("EDR_amplification", _constants_v2_v3.edrAmplification);
-			setups[i]->set("EDA_crossover_filter_frequency", _constants_v2_v3.crossoverFilterFreq);
-			setups[i]->set("VCC", _constants_v2_v3.vcc);
-			setups[i]->set("ISR_ADC_offset_correction", _constants_v2_v3.isrOffsetCorr);
+			setups[i]["voltage_reference_1"] = _constants_v2_v3.vRef1;
+			setups[i]["voltage_reference_2"] = _constants_v2_v3.vRef2;
+			setups[i]["EDA_feedback_amp_resistance"] = _constants_v2_v3.feedbackAmpR;
+			setups[i]["EDR_amplification"] = _constants_v2_v3.edrAmplification;
+			setups[i]["EDA_crossover_filter_frequency"] = _constants_v2_v3.crossoverFilterFreq;
+			setups[i]["VCC"] = _constants_v2_v3.vcc;
+			setups[i]["ISR_ADC_offset_correction"] = _constants_v2_v3.isrOffsetCorr;
 		}
 
-		if (root.printTo(jsonFile) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		serializeJson(jsonDoc, jsonFile);
 	}
 	jsonFile.print(",");
 	// Skin Coductance Response Amplitude
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		const uint8_t nInfo = 1;
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
-		infos[i]->set("name", "SkinConductanceResponseAmplitude");
-		infos[i]->set("type", "ElectrodermalActivity");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add(EmotiBitPacket::TypeTag::SKIN_CONDUCTANCE_RESPONSE_AMPLITUDE);
-		infos[i]->set("channel_count", 1);
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "microsiemens");
-		if (root.printTo(jsonFile) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i] = root.createNestedObject("info");
+		infos[i]["name"] = "SkinConductanceResponseAmplitude";
+		infos[i]["type"] = "ElectrodermalActivity";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add(EmotiBitPacket::TypeTag::SKIN_CONDUCTANCE_RESPONSE_AMPLITUDE);
+		infos[i]["channel_count"] = 1;
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "microsiemens";
+		serializeJson(jsonDoc, jsonFile);
 	}
 	jsonFile.print(",");
 	// Skin Coductance Response Frequency
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		const uint8_t nInfo = 1;
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
-		infos[i]->set("name", "SkinConductanceResponseFrequency");
-		infos[i]->set("type", "ElectrodermalActivity");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add(EmotiBitPacket::TypeTag::SKIN_CONDUCTANCE_RESPONSE_FREQ);
-		infos[i]->set("channel_count", 1);
-		infos[i]->set("nominal_srate", _constants.samplingRate / _constants.EDA_SAMPLES_PER_SCR_FREQ_OUTPUT);
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "count/min");
-		if (root.printTo(jsonFile) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i] = root.createNestedObject("info");
+		infos[i]["name"] = "SkinConductanceResponseFrequency";
+		infos[i]["type"] = "ElectrodermalActivity";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add(EmotiBitPacket::TypeTag::SKIN_CONDUCTANCE_RESPONSE_FREQ);
+		infos[i]["channel_count"] = 1;
+		infos[i]["nominal_srate"] = _constants.samplingRate / _constants.EDA_SAMPLES_PER_SCR_FREQ_OUTPUT;
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "count/min";
+		serializeJson(jsonDoc, jsonFile);
 	}
 	jsonFile.print(",");
 	// Skin Coductance Response Rise Time
 	{
 		// Parse the root object
-		StaticJsonBuffer<bufferSize> jsonBuffer;
-		JsonObject &root = jsonBuffer.createObject();
+		StaticJsonDocument<bufferSize> jsonDoc;
+		JsonObject root = jsonDoc.to<JsonObject>();
 		const uint8_t nInfo = 1;
-		JsonObject* infos[nInfo];
-		JsonArray* typeTags[nInfo];
-		JsonObject* setups[nInfo];
+		JsonObject infos[nInfo];
+		JsonArray typeTags[nInfo];
+		JsonObject setups[nInfo];
 		uint8_t i = 0;
-		infos[i] = &(root.createNestedObject("info"));
-		infos[i]->set("name", "SkinConductanceResponseRiseTime");
-		infos[i]->set("type", "ElectrodermalActivity");
-		typeTags[i] = &(infos[i]->createNestedArray("typeTags"));
-		typeTags[i]->add(EmotiBitPacket::TypeTag::SKIN_CONDUCTANCE_RESPONSE_RISE_TIME);
-		infos[i]->set("channel_count", 1);
-		infos[i]->set("channel_format", "float");
-		infos[i]->set("units", "secs");
-		if (root.printTo(jsonFile) == 0) {
-#ifdef DEBUG
-			Serial.println(F("Failed to write to file"));
-#endif
-		}
+		infos[i] = root.createNestedObject("info");
+		infos[i]["name"] = "SkinConductanceResponseRiseTime";
+		infos[i]["type"] = "ElectrodermalActivity";
+		typeTags[i] = infos[i].createNestedArray("typeTags");
+		typeTags[i].add(EmotiBitPacket::TypeTag::SKIN_CONDUCTANCE_RESPONSE_RISE_TIME);
+		infos[i]["channel_count"] = 1;
+		infos[i]["channel_format"] = "float";
+		infos[i]["units"] = "secs";
+		serializeJson(jsonDoc, jsonFile);
 	}
 	return true;
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit FeatherWing
-version=1.9.1
+version=1.9.0
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A library written for EmotiBit FeatherWing that supports all sensors included on the wing.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit FeatherWing
-version=1.8.1
+version=2.0.0
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A library written for EmotiBit FeatherWing that supports all sensors included on the wing.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EmotiBit FeatherWing
-version=2.0.0
+version=1.9.1
 author=Connected Future Labs
 maintainer=Connected Future Labs <info@connectedfuturelabs.com>
 sentence=A library written for EmotiBit FeatherWing that supports all sensors included on the wing.


### PR DESCRIPTION
# Description
Updating the ArduinoJson library to the latest version  and added free_memory() to display during bootup.

# Requirements
- ArduinoJson version 6


# Issues Referenced
- Fixes #31 

# Documentation update
Documentation should be changed under:
Keeping EmotiBit up-to date => Update firmware using Arduino IDE => Library List
where "ArduinoJson (version 5.13.5, not v6.x.x)" should be replaced with "ArduinoJson" since it is the latest version.

PR to documentation change.
- https://github.com/EmotiBit/EmotiBit_Docs/pull/113

# Notes for Reviewer
- https://github.com/EmotiBit/EmotiBit_FeatherWing/pull/39 (Existing PR on upgrade)
The ArduinoJson Library must be updated to 6, the changes will not work with version 5. 
The free memory function was added to the function where emotibit data is displayed. This was only added in the case a featherwing m0 is used.

# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->


## Results
<!--- The main results should be recorded in the appropriate testing results sheet -->

Test to make sure config.txt file is still being parsed as expected.
| Parse Results | Comments |
| ------------- | ----------- |
| <img width="616" alt="Screenshot 2023-06-15 at 11 25 04 AM" src="https://github.com/EmotiBit/EmotiBit_FeatherWing/assets/90929134/9dcaf439-71b3-4609-b3f0-221be628d3b6"> | The config.txt is parsed correctly but missing values are stored as a string "null" rather than an actual null value. This get around this, an if statement is used to set "null" strings to "". | 

Test to make sure the `info.json` file created when a recording is started is the same as the one created with the currect release.

| Info.json diff results | Comments |
| -------------------- | ----------- |
| <img width="698" alt="Screenshot 2023-06-15 at 11 54 00 AM" src="https://github.com/EmotiBit/EmotiBit_FeatherWing/assets/90929134/e92efa47-4e90-46fb-a551-cc7c8085ad42"> | The only difference is in char 263, line 1 | 
| <img width="182" alt="Screenshot 2023-06-15 at 11 54 42 AM" src="https://github.com/EmotiBit/EmotiBit_FeatherWing/assets/90929134/162bf7c4-3839-46ec-8869-301319f40e4b"> | The difference is the firmware version |
| <img width="180" alt="Screenshot 2023-06-15 at 11 56 57 AM" src="https://github.com/EmotiBit/EmotiBit_FeatherWing/assets/90929134/8ef382fd-1377-4375-81fd-121b5b4de01f"> | Previous firmware version | 

The library update reduces the memory used by the EmotiBit which was checked using the free memory function as seen here.

| Memory Before | Memory After |
| --------------- | -------------- |
| <img width="359" alt="Free_Memory_Old" src="https://github.com/EmotiBit/EmotiBit_FeatherWing/assets/90929134/7eb4d071-7f69-462b-ab6f-877237e916ab"> | <img width="365" alt="Free_Memory_new" src="https://github.com/EmotiBit/EmotiBit_FeatherWing/assets/90929134/da38d03b-2841-4714-8755-30df3a5f81f9"> |


## Feature Tests
<!--- For each test case, create a unit test in the `EmotiBit Feature Test Protocol` document. -->
<!--- For firmware, the corresponding results recorded in the `EmotiBit Feature Testing Results` sheet. -->
<!--- For software, the corresponding results are recorded in the `EmotiBit Software Testing Records` sheet. -->
Add the test heading from "EmotiBit Feature Test Protocol" here.

## Steps to test
Import the steps from the `EmotiBit Feature Test Protocol` for quick access for the reviewer

# Shared files
- Firmware binary: [1.8.1.fix-JsonLibUpdate.1.zip](https://github.com/EmotiBit/EmotiBit_FeatherWing/files/11763486/1.8.1.fix-JsonLibUpdate.1.zip)

- Other files.


# Checklist to allow merge
- [x] All dependent repositories used were on branch `master`
- Software
  - [ ] Get approval from the reviewer
  - [ ] Passed testing on Windows
  - [ ] Passed testing on macOS *(for major changes/GUI changes/ PRs adding files distributed with the EmotiBit software)*
  - [ ] Passed testing on linux (ubuntu) *(for major changes/GUI changes/ PRs adding files distributed with the EmotiBit software)*
  - [ ] Update software bundle version in `ofxEmotiBitVersion.h`
- Firmware
  - [x] Set testingMode to TestingMode::NONE
  - [x] Set const bool `DIGITAL_WRITE_DEBUG` = false (if set true while testing)
  - [x] Update version in EmotiBit.h
  - [x] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] doxygen style comments included for new code snippets
- [x] Required documentation updated