### PR TITLE
Feat external board definition version control

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -2033,7 +2033,7 @@ int8_t EmotiBit::updateIMUData(bool acquireAccGyro, bool chipBegunMag, bool acqu
 			bytesToRead = 0;
 		}
 	}
-	Serial.print("bytesToRead= "); Serial.println(bytesToRead);
+	//Serial.print("bytesToRead= "); Serial.println(bytesToRead);
 
 	bool imuBufferFull = false;
 	uint16_t nFrames = 1;

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -4632,6 +4632,17 @@ void EmotiBit::setupFailedConfigMode(const String failureMode, int buttonPin)
 	}
 }
 
+// New function for parsing recieved packet
+/*
+	Plan is to loop through string starting at @ to the , and set tag to this value
+	then assign value from , to ~ to payload.
+*/
+void EmotiBit::ParseSdCardPacket(String c, String* tag, String* payload)
+{
+	
+	Serial.println(c);
+}
+
 void EmotiBit::processWifiConfigInputs()
 {
 	Serial.println("Successfully entered config mode.");
@@ -4641,8 +4652,10 @@ void EmotiBit::processWifiConfigInputs()
 		{
 			// Using readString() to receive packets
 			String c = Serial.readString();
+			String tag, payload;
 
 			// Need parser to parse @ and ~ here
+			ParseSdCardPacket(c, &tag, &payload);
 
 			if (c == EmotiBitPacket::TypeTag::WIFI_ADD){
 				Serial.println("WA recieved");

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -4831,6 +4831,7 @@ void EmotiBit::processWifiConfigInputs()
 						for(int i = 0; i < configAsJson["WifiCredentials"].size(); i++ )
 						{
 							Serial.print(i); Serial.print(". " + configAsJson["WifiCredentials"][i]["ssid"].as<String>());
+							Serial.print(" : "); Serial.print(configAsJson["WifiCredentials"][i]["password"].as<String>());
 							Serial.println();
 						}
 					}

--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -4617,6 +4617,8 @@ void EmotiBit::restartMcu()
 #endif
 }
 
+
+// ToDo: This function can probably be moved to another class/file. The only dependency on EmotiBit class is _configFilename
 void EmotiBit::processWifiConfigInputs()
 {
 	Serial.println("Successfully entered config file edit mode.");

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.9";
+  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.13";
 
 
 
@@ -519,8 +519,16 @@ public:
 	 * @brief Function to perform a software reset on the MCU
 	 */
 	void restartMcu();
+	
 	/*!
 	 * @brief Function to edit WiFi credentials in config file using serial input.
+	 *
+	 * Use this function to Add or Delete credentials from SD-Card.
+	 * Typetag WA (WiFi-Add) is used to add credentials. 
+	 *     Syntax: @WA,{\"ssid\":\"SSSS\",\"password\" : \"PPPP\"}~
+	 * Tyeptag WD (WiFi-Delete) is used to delete credentials.
+	 *     Syntax: @WD,<cred_number>~ to delte cred. 
+	 * Typetag LS (LIST) lists current credentials
 	 */
 	void processWifiConfigInputs();
 	// ----------- END ino refactoring ---------------

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -12,7 +12,7 @@
 #include <EmotiBit_Si7013.h>
 #include <BMI160Gen.h>
 #include <MAX30105.h>
-#include <EmotiBit_NCP5623.h>
+#include <EmotiBitLedController.h>
 #include <SparkFun_MLX90632_Arduino_Library.h>
 #include "DoubleBufferFloat.h"
 #include <ArduinoJson.h>
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.14";
+  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.14.feat-boardversionControl.0";
 
 
 
@@ -245,12 +245,6 @@ public:
   	TIME_FILESYNC  //time taken for file syncing
   };
 
-  //TODO: Make enum classs for led's
-  enum class Led {
-	  RED = 1,
-	  BLUE,
-	  YELLOW
-  };
 
   enum class BattLevel {
 	  THRESHOLD_HIGH = 50, // Set thresholds for changing led indication on board for battery
@@ -276,7 +270,7 @@ public:
 	PPGSettings ppgSettings;
 	IMUSettings imuSettings;
 	MAX30105 ppgSensor;
-	NCP5623 led;
+	EmotiBitLedController _ledController;
 	MLX90632 thermopile;
 	EmotiBitEda emotibitEda;
 	EmotiBitNvmController _emotibitNvmController;
@@ -363,18 +357,7 @@ public:
 	//	uint8_t battery = 0;
 	//} timerLoopOffset;	// Sets initial value of sampling counters
 
-	struct AcquireData {
-		bool eda = true;
-		bool tempHumidity = true;
-		bool thermopile = true;
-		bool imu = true;
-		bool ppg = true;
-		bool tempPpg = true;
-		bool debug = false;
-		bool battery = true;
-		bool heartRate = true; // Note: we may want to move this to a separarte flag someday, for controlling derivative signals
-		bool edrMetrics = true;
-	} acquireData;
+ 	EmotiBitVersionController::AcquireData acquireData;
 
 	struct ChipBegun {
 		bool SI7013 = false;
@@ -589,7 +572,7 @@ private:
 	uint8_t _adcBits;
 	float _accelerometerRange; // supported values: 2, 4, 8, 16 (G)
 	float _gyroRange; // supported values: 125, 250, 500, 1000, 2000 (degrees/second)
-	EmotiBitVersionController::EmotiBitVersion _hwVersion;
+	EmotiBitVersionController::EmotiBitVersion _hwVersion = EmotiBitVersionController::EmotiBitVersion::UNKNOWN;
 #if defined(ARDUINO_FEATHER_ESP32)
 	String _featherVersion = "Adafruit Feather HUZZAH32";
 #elif defined(ADAFRUIT_FEATHER_M0)

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.13";
+  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.14";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -520,6 +520,7 @@ public:
 	 */
 	void restartMcu();
 	void processWifiConfigInputs();
+	void ParseSdCardPacket(String c, String* tag, String* payload);
 	void setupFailedConfigMode(const String failureMode, int buttonPin = -1);
 	// ----------- END ino refactoring ---------------
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.14.feat-boardversionControl.0";
+  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.14.feat-boardversionControl.1";
 
 
 
@@ -357,7 +357,22 @@ public:
 	//	uint8_t battery = 0;
 	//} timerLoopOffset;	// Sets initial value of sampling counters
 
- 	EmotiBitVersionController::AcquireData acquireData;
+ 	struct AcquireData 
+	{
+	bool eda = true;
+	bool tempHumidity = true;
+	bool thermopile = true;
+	bool imuAccGyro = true;
+	bool imuMag = true;
+	bool ppg = true;
+	bool tempPpg = true;
+	bool debug = false;
+	bool battery = true;
+	bool heartRate = true; // Note: we may want to move this to a separarte flag someday, for controlling derivative signals
+	bool edrMetrics = true;
+	}acquireData;
+
+	InitControllers _initControllers;
 
 	struct ChipBegun {
 		bool SI7013 = false;
@@ -527,7 +542,7 @@ public:
   uint8_t setup(String firmwareVariant = "");   /**< Setup all the sensors */
 	uint8_t update();
   void setAnalogEnablePin(uint8_t i); /**< Power on/off the analog circuitry */
-  int8_t updateIMUData();                /**< Read any available IMU data from the sensor FIFO into the inputBuffers */
+  int8_t updateIMUData(bool acquireAccGyro, bool chipBegunMag, bool acquireMag);                /**< Read any available IMU data from the sensor FIFO into the inputBuffers */
 	int8_t updatePPGData();                /**< Read any available PPG data from the sensor FIFO into the inputBuffers */
 	int8_t updateTempHumidityData();       /**< Read any available temperature and humidity data into the inputBuffers */
 	int8_t updatePpgTempData();			/**< Read any available temp data from PPG into buffer*/

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.14.feat-boardversionControl.2";
+  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.14.feat-boardversionControl.3";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.8";
+  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.9";
 
 
 
@@ -427,7 +427,7 @@ public:
 	bool startBufferOverflowTest = false;
 
 	void setupFailed(const String failureMode, int buttonPin = -1, bool configFileError = false);
-	bool setupSdCard();
+	bool setupSdCard(bool loadConfig = true);
 	void updateButtonPress();
 	void sleep(bool i2cSetupComplete = true);
 	void startTimer(int frequencyHz);
@@ -519,6 +519,9 @@ public:
 	 * @brief Function to perform a software reset on the MCU
 	 */
 	void restartMcu();
+	/*!
+	 * @brief Function to edit WiFi credentials in config file using serial input.
+	 */
 	void processWifiConfigInputs();
 	// ----------- END ino refactoring ---------------
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.14.feat-boardversionControl.1";
+  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.14.feat-boardversionControl.2";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0";
+  String firmware_version = "1.9.0.feat-sdCardWiFiCredentials.8";
 
 
 
@@ -68,7 +68,7 @@ public:
 
 	const bool DC_DO_V2 = true;
 
-	bool _debugMode = true;
+	bool _debugMode = false;
 	bool dummyIsrWithDelay = false;
 	uint32_t targetFileSyncDelay = 1;
 	struct ReadSensorsDurationMax
@@ -426,7 +426,7 @@ public:
 	volatile bool buttonPressed = false;
 	bool startBufferOverflowTest = false;
 
-	void setupFailed(const String failureMode, int buttonPin = -1);
+	void setupFailed(const String failureMode, int buttonPin = -1, bool configFileError = false);
 	bool setupSdCard();
 	void updateButtonPress();
 	void sleep(bool i2cSetupComplete = true);
@@ -520,8 +520,6 @@ public:
 	 */
 	void restartMcu();
 	void processWifiConfigInputs();
-	void ParseSdCardPacket(String c, String* tag, String* payload);
-	void setupFailedConfigMode(const String failureMode, int buttonPin = -1);
 	// ----------- END ino refactoring ---------------
 
 	

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -68,7 +68,7 @@ public:
 
 	const bool DC_DO_V2 = true;
 
-	bool _debugMode = false;
+	bool _debugMode = true;
 	bool dummyIsrWithDelay = false;
 	uint32_t targetFileSyncDelay = 1;
 	struct ReadSensorsDurationMax
@@ -519,6 +519,8 @@ public:
 	 * @brief Function to perform a software reset on the MCU
 	 */
 	void restartMcu();
+	void processWifiConfigInputs();
+	void setupFailedConfigMode(const String failureMode, int buttonPin = -1);
 	// ----------- END ino refactoring ---------------
 
 	

--- a/EmotiBitLedController.cpp
+++ b/EmotiBitLedController.cpp
@@ -1,0 +1,99 @@
+#include "EmotiBitLedController.h"
+
+bool EmotiBitLedController::init(EmotiBitVersionController::EmotiBitVersion hwVersion, TwoWire &_i2c, int driverCurrent)
+{
+     _hwVersion = hwVersion;
+    if((int)_hwVersion == (int)EmotiBitVersionController::EmotiBitVersion::AGAVE_REVB)
+    {
+        // No IC to initialize. LEDs are controlled using GPIOs.
+        // Set GPIOs and set type
+        // ToDo: Maybe pin assignment information shoulde live in versionController
+        _ledPin[Led::RECORDING] = 25;
+        _ledPin[Led::WIFI] = 33;
+        _ledPin[Led::BATTERY] = 26;
+        pinMode(_ledPin[Led::RECORDING], OUTPUT);
+        pinMode(_ledPin[Led::WIFI], OUTPUT);
+        pinMode(_ledPin[Led::BATTERY], OUTPUT);
+        return true;
+    }
+    else
+    {
+        // ToDo: check for other boards except EmotiBit
+        Serial.print("Initializing NCP5623....");
+        // ToDo: add a success or fail return statement for LED driver
+        bool status = ncp.begin(_i2c);
+        if (status)
+        {
+            // check if the LED current level is valid.
+            if (driverCurrent > 0)
+            {
+                ncp.setCurrent(driverCurrent);
+            }
+            ncp.setLEDpwm(NCP5623::LED1, 8);
+            ncp.setLEDpwm(NCP5623::LED2, 8);
+            ncp.setLEDpwm(NCP5623::LED3, 8);
+            ncp.setLED(NCP5623::LED1, false);
+            ncp.setLED(NCP5623::LED2, false);
+            ncp.setLED(NCP5623::LED3, false);
+            ncp.send();
+            Serial.println("Completed");
+            return true;
+        }
+        return false;
+    }
+
+}
+
+void EmotiBitLedController::setState(Led led, bool state)
+{
+    if((int)_hwVersion  == (int)EmotiBitVersionController::EmotiBitVersion::AGAVE_REVB)
+    {
+        // set state of LED
+        if(_ledState[led] != state)
+        {
+            _ledState[led] = state;
+            _ledChanged[led] = true;
+        }
+    }
+    else
+    {
+        int ncpLed;
+        if(led == Led::RECORDING)
+        {
+            ncpLed = 1;
+        }
+        else if (led == Led::WIFI)
+        {
+            ncpLed = 2;
+        }
+        else if (led == Led::BATTERY)
+        {
+            ncpLed = 3;
+        }
+        ncp.setLED(ncpLed, state);
+    }
+}
+
+bool EmotiBitLedController::update()
+{
+    if((uint8_t)_hwVersion  == (uint8_t)EmotiBitVersionController::EmotiBitVersion::AGAVE_REVB)
+    {
+        for(uint8_t led = 0; led < LED_COUNT; led++)
+        {
+            if(_ledChanged[led])
+            {
+                digitalWrite(_ledPin[led], _ledState[led]);
+            }
+        }
+    }
+    else
+    {
+        ncp.send();
+    }
+    return true;
+}
+
+bool EmotiBitLedController::getState(Led led)
+{
+    return _ledState[led];
+}

--- a/EmotiBitLedController.h
+++ b/EmotiBitLedController.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <EmotiBit_NCP5623.h>
+#include "EmotiBitVersionController.h"
+#include "Arduino.h"
+class EmotiBitLedController
+{
+public:
+    enum Led{
+        RECORDING = 0,
+        WIFI = 1,
+        BATTERY = 2,
+    };
+    const static uint8_t LED_COUNT = 3;  // ToDO: this needs to change as itmay depend on the board version
+    bool _ledState[LED_COUNT];
+    bool _ledChanged[LED_COUNT];
+    uint8_t _ledPin[LED_COUNT];
+    EmotiBitVersionController::EmotiBitVersion _hwVersion;
+    NCP5623 ncp;
+
+    bool init(EmotiBitVersionController::EmotiBitVersion hwVersion, TwoWire &_i2c, int driverCurrent);
+    void setState(Led led, bool state);
+    bool getState(Led led);
+    bool update();
+};

--- a/EmotiBitNvmController.cpp
+++ b/EmotiBitNvmController.cpp
@@ -29,32 +29,40 @@
 
 #include "EmotiBitNvmController.h"
 
-bool EmotiBitNvmController::init(TwoWire &emotibit_i2c)
+bool EmotiBitNvmController::init(TwoWire &emotibit_i2c, bool skipInit)
 {
-
-	if (emotibitEeprom.begin(EMOTIBIT_EEPROM_I2C_ADDRESS, emotibit_i2c))
+	if(skipInit)
 	{
-		emotibitEepromSettings.capacityBytes = 256; // in bytes
-		emotibitEepromSettings.pageSizeBytes = 16; // in bytes
-		emotibitEeprom.setMemorySize(emotibitEepromSettings.capacityBytes);
-		emotibitEeprom.setPageSize(emotibitEepromSettings.pageSizeBytes);
-		writeState = State::IDLE;
-		readState = State::IDLE;
-		_nvmType = NvmType::EEPROM;
+		Serial.println("Check skipped.");
 		return true;
 	}
-
-	if (si7013.setup(emotibit_i2c))
+	else
 	{
-		writeState = State::IDLE;
-		readState = State::IDLE;
-		_nvmType = NvmType::OTP;
-		return true;
+		if (emotibitEeprom.begin(EMOTIBIT_EEPROM_I2C_ADDRESS, emotibit_i2c))
+		{
+			emotibitEepromSettings.capacityBytes = 256; // in bytes
+			emotibitEepromSettings.pageSizeBytes = 16; // in bytes
+			emotibitEeprom.setMemorySize(emotibitEepromSettings.capacityBytes);
+			emotibitEeprom.setPageSize(emotibitEepromSettings.pageSizeBytes);
+			writeState = State::IDLE;
+			readState = State::IDLE;
+			_nvmType = NvmType::EEPROM;
+			Serial.println("success");
+			return true;
+		}
+
+		if (si7013.setup(emotibit_i2c))
+		{
+			writeState = State::IDLE;
+			readState = State::IDLE;
+			_nvmType = NvmType::OTP;
+			Serial.println("success");
+			return true;
+		}
+
+		_nvmType = NvmType::UNKNOWN;
+		return false;
 	}
-
-	_nvmType = NvmType::UNKNOWN;
-	return false;
-
 }
 
 uint8_t EmotiBitNvmController::stageToWrite(DataType datatype, uint8_t datatypeVersion, uint32_t dataSize, uint8_t* data, bool autoSync, bool enableValidateWrite)

--- a/EmotiBitNvmController.h
+++ b/EmotiBitNvmController.h
@@ -131,7 +131,7 @@ public:
 		@param emotiBit_i2c I2C instance being used by EmotiBit to talk to sensors.
 		@return True if successful, otherwise false.
 	*/
-	bool init(TwoWire &emotiBit_i2c);
+	bool init(TwoWire &emotiBit_i2c, bool skipInit);
 
 	/*
 		@brief Updates the write buffer with data that will be written to the NVM.

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -653,7 +653,7 @@ bool EmotiBitVersionController::checkForExternalVersionDefinition(EmotiBitVersio
 	initControllers.eda = false;
 	initControllers.tempHumidity = false;
 	initControllers.thermopile = false;
-	initControllers.imuMag = false;
+	initControllers.imuMag = true;
 	return true;
 #endif
 #endif

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -67,6 +67,10 @@ const char* EmotiBitVersionController::getHardwareVersion(EmotiBitVersion versio
 	{
 		return "V05c\0";
 	}
+	else if (version == EmotiBitVersion::AGAVE_REVB)
+	{
+		return "AGAVE_REVB\0";
+	}
 	else
 	{
 		return "NA\0";
@@ -471,8 +475,9 @@ bool EmotiBitVersionController::writeVariantInfoToNvm(EmotiBitNvmController &emo
 	}
 }
 
-bool EmotiBitVersionController::getEmotiBitVariantInfo(EmotiBitNvmController &emotiBitNvmController, EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode)
+bool EmotiBitVersionController::getEmotiBitVariantInfo(EmotiBitNvmController &emotiBitNvmController, EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, AcquireData &acquireData)
 {
+
 	uint8_t* nvmData;
 	uint8_t datatypeVersion;
 	uint32_t dataSize;
@@ -532,6 +537,7 @@ bool EmotiBitVersionController::getEmotiBitVariantInfo(EmotiBitNvmController &em
 		Serial.print("Failed to read Variant Info. Error Code: "); Serial.println(status);
 		return false;
 	}
+
 }
 
 void EmotiBitVersionController::updateVersionParameterTable(TwoWire &emotibit_i2c, EmotiBitHardwareParameterTable &hardwareParameterTable)
@@ -632,4 +638,24 @@ bool EmotiBitVersionController::detectVariantFromHardware(TwoWire &emotibit_i2c,
 		}
 	}
 	
+}
+
+
+bool EmotiBitVersionController::checkForExternalVersionDefinition(EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, AcquireData &acquireData)
+{
+#ifdef EXT_BOARD_DEFINED
+#ifdef AGAVE_REVB_V01C
+	Serial.println("Agave revb v01c defined in project files");
+	hwVersion = EmotiBitVersion::AGAVE_REVB;
+	sku = "v01C";
+	emotibitSerialNumber = 01;
+	barcode = "Agave RevB"; // this is the device ID in EmotiBit
+	acquireData.eda = false;
+	acquireData.edrMetrics = false;
+	acquireData.tempHumidity = false;
+	acquireData.thermopile = false;
+	return true;
+#endif
+#endif
+	return false;
 }

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -653,7 +653,7 @@ bool EmotiBitVersionController::checkForExternalVersionDefinition(EmotiBitVersio
 	initControllers.eda = false;
 	initControllers.tempHumidity = false;
 	initControllers.thermopile = false;
-	initControllers.imuMag = true;
+	initControllers.imuMag = false;
 	return true;
 #endif
 #endif

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -475,7 +475,7 @@ bool EmotiBitVersionController::writeVariantInfoToNvm(EmotiBitNvmController &emo
 	}
 }
 
-bool EmotiBitVersionController::getEmotiBitVariantInfo(EmotiBitNvmController &emotiBitNvmController, EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, AcquireData &acquireData)
+bool EmotiBitVersionController::getEmotiBitVariantInfo(EmotiBitNvmController &emotiBitNvmController, EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, InitControllers &initControllers)
 {
 
 	uint8_t* nvmData;
@@ -641,7 +641,7 @@ bool EmotiBitVersionController::detectVariantFromHardware(TwoWire &emotibit_i2c,
 }
 
 
-bool EmotiBitVersionController::checkForExternalVersionDefinition(EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, AcquireData &acquireData)
+bool EmotiBitVersionController::checkForExternalVersionDefinition(EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, InitControllers &initControllers)
 {
 #ifdef EXT_BOARD_DEFINED
 #ifdef AGAVE_REVB_V01C
@@ -650,10 +650,10 @@ bool EmotiBitVersionController::checkForExternalVersionDefinition(EmotiBitVersio
 	sku = "v01C";
 	emotibitSerialNumber = 01;
 	barcode = "Agave RevB"; // this is the device ID in EmotiBit
-	acquireData.eda = false;
-	acquireData.edrMetrics = false;
-	acquireData.tempHumidity = false;
-	acquireData.thermopile = false;
+	initControllers.eda = false;
+	initControllers.tempHumidity = false;
+	initControllers.thermopile = false;
+	initControllers.imuMag = false;
 	return true;
 #endif
 #endif

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -77,7 +77,17 @@ enum class VregEnablePinLogic
 	ACTIVE_HIGH
 };
 
-
+struct InitControllers
+{
+	bool eda = true;
+	bool tempHumidity = true;
+	bool thermopile = true;
+	bool imuAccGyro = true;
+	bool imuMag = true;
+	bool ppg = true;
+	bool tempPpg = true;
+	bool battery = true;
+};
 class EmotiBitVersionController
 {
 public: 	
@@ -116,19 +126,6 @@ public:
 		bool isThermopilePresent;
 	};
 
-	struct AcquireData 
-	{
-	bool eda = true;
-	bool tempHumidity = true;
-	bool thermopile = true;
-	bool imu = true;
-	bool ppg = true;
-	bool tempPpg = true;
-	bool debug = false;
-	bool battery = true;
-	bool heartRate = true; // Note: we may want to move this to a separarte flag someday, for controlling derivative signals
-	bool edrMetrics = true;
-	};
 
 private:
 	static const int _MAX_EMOTIBIT_PIN_COUNT = 28;
@@ -227,7 +224,7 @@ public:
 		@param emotibitSerialNumber the EmotiBit Number read from the version(for V4+ only)
 		@return returns True, if Variant information successfully retrieved from the NVM, else False
 	*/
-	bool getEmotiBitVariantInfo(EmotiBitNvmController &emotiBitNvmController, EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, AcquireData &acquireData);
+	bool getEmotiBitVariantInfo(EmotiBitNvmController &emotiBitNvmController, EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, InitControllers &initControllers);
 	
 	/*!
 		@brief fallback function to detect version from HW, if variant information not stored in NVM
@@ -264,6 +261,6 @@ public:
 	*/
 	void echoPinMapping();
 
-	bool checkForExternalVersionDefinition(EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, AcquireData &acquireData);
+	bool checkForExternalVersionDefinition(EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, InitControllers &initControllers);
 };
 #endif

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -77,6 +77,7 @@ enum class VregEnablePinLogic
 	ACTIVE_HIGH
 };
 
+
 class EmotiBitVersionController
 {
 public: 	
@@ -105,6 +106,7 @@ public:
 		V03B = 5,
 		V04A = 6,
 		V05C = 7,
+		AGAVE_REVB = 8,
 		length
 	};
 
@@ -112,6 +114,20 @@ public:
 		bool isSi7013Present;
 		bool isEepromPresent;
 		bool isThermopilePresent;
+	};
+
+	struct AcquireData 
+	{
+	bool eda = true;
+	bool tempHumidity = true;
+	bool thermopile = true;
+	bool imu = true;
+	bool ppg = true;
+	bool tempPpg = true;
+	bool debug = false;
+	bool battery = true;
+	bool heartRate = true; // Note: we may want to move this to a separarte flag someday, for controlling derivative signals
+	bool edrMetrics = true;
 	};
 
 private:
@@ -211,7 +227,7 @@ public:
 		@param emotibitSerialNumber the EmotiBit Number read from the version(for V4+ only)
 		@return returns True, if Variant information successfully retrieved from the NVM, else False
 	*/
-	bool getEmotiBitVariantInfo(EmotiBitNvmController &emotiBitNvmController, EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode);
+	bool getEmotiBitVariantInfo(EmotiBitNvmController &emotiBitNvmController, EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, AcquireData &acquireData);
 	
 	/*!
 		@brief fallback function to detect version from HW, if variant information not stored in NVM
@@ -247,5 +263,7 @@ public:
 		@brief Prints all pin mappings on the screen
 	*/
 	void echoPinMapping();
+
+	bool checkForExternalVersionDefinition(EmotiBitVersion &hwVersion, String &sku, uint32_t &emotibitSerialNumber, String &barcode, AcquireData &acquireData);
 };
 #endif

--- a/EmotiBitWiFi.cpp
+++ b/EmotiBitWiFi.cpp
@@ -860,3 +860,8 @@ bool EmotiBitWiFi::isEnterpriseNetworkListed()
 	}
 	return false;
 }
+
+uint8_t EmotiBitWiFi::getMaxNumCredentialAllowed()
+{
+	return MAX_CREDENTIALS;
+}

--- a/EmotiBitWiFi.h
+++ b/EmotiBitWiFi.h
@@ -167,4 +167,10 @@ public:
 	   @return true is enterprise network is listed, else false
 	 */
 	bool isEnterpriseNetworkListed();
+
+	/*!
+	 * @brief Returns max number of allowed credentials in EmotiBitWiFi
+	 * @return NAX_CREDENTIAL
+	 */
+	static uint8_t getMaxNumCredentialAllowed();
 };

--- a/EmotiBit_stock_firmware/platformio.ini
+++ b/EmotiBit_stock_firmware/platformio.ini
@@ -10,13 +10,14 @@
 [platformio]
 extra_configs = 
     ../board_feather_m0.ini
-    ../board_feather_esp32.ini
+    ../board_feather_esp32_v2.ini
 src_dir = ./
 lib_dir = ../../
 
 
 [custom]
 variant_flags = -DSTOCK_FIRMWARE
+ext_board_def_flags = -DEXT_BOARD_DEFINED -DAGAVE_REVB_V01C
 
 [env]
 lib_ldf_mode = deep+

--- a/board_feather_esp32_v2.ini
+++ b/board_feather_esp32_v2.ini
@@ -1,0 +1,11 @@
+[env:adafruit_feather_esp32_v2]
+;parity with ESP Arduino v2.0.7. check release notes: https://github.com/platformio/platform-espressif32/releases/tag/v6.1.0
+platform = espressif32 @6.1.0
+board = adafruit_feather_esp32_v2
+framework = arduino
+build_flags = 
+    -DARDUINO_FEATHER_ESP32 ${custom.variant_flags} ${custom.ext_board_def_flags}
+; change MCU frequency
+board_build.f_cpu = 240000000L
+extra_scripts = pre:../pio_scripts/renameFw.py
+firmware_name_board_name = feather_esp32_v2


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
- **Adds provision for Agave RevB**
- Adds LED controller
- Improves NVM controller by providing hwVersion for `init`
- versionController class has a new provision to check for HW (device) definitions in the project files
- Project file (platform ini) has a new section that enables #defines for boards. This way, a board version can be passed as compile time to compile for a specific target

# Usage
- To compile from source you will need to install the platformIO build chain. Check out the [EmotiBit documentation](https://github.com/EmotiBit/EmotiBit_Docs/blob/master/Keep_emotibit_up_to_date.md#building-firmware-using-platformio) to setup platformIO.
- Once the platformIO build environment is setup, switch to [this branch](https://github.com/EmotiBit/EmotiBit_FeatherWing/tree/feat-boardVersionControl) in EmotiBit_FeatherWing repo and you should be able to compile it from source.
- Make sure you are building for the [correct board](https://github.com/EmotiBit/EmotiBit_FeatherWing/blob/4c2707cae6c631051858256cf4c9f6a49201021f/EmotiBit_stock_firmware/platformio.ini#L13).
- Follow the [PlatformIO documentation](https://docs.platformio.org/en/latest/tutorials/index.html) for build and upload process.

# Merge requirements
- Complete #283 before merging this PR

# Outstanding Issues
<!-- If Any -->
- #288 
- #289


# Documentation update
- None

# Notes for Reviewer
- ⚠️WIP
  - IMU
    - The `updateImuData()` has some low level driver stuff pulled up to EmotiBit class to enable reading 12 bytes of data in a case when BMM150 is not present.
    - That needs to move back to the driver and not be scattered in EmotiBit.cpp
  - NVM controller & LedController
    - Currently, hwversion is passed to NVM controller to skip NVM init based on hw
    - This is spec'd to be changed in the future where a init call is controlled by EmotiBit based on hw version.
    - Since it may change, it is worth discussing the next move here.

# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->
<!--- If another **linked PR** is the main PR for this bug-fix/ feature-add, you may then remove this testing section and add a link to the main PR here with the explicit statement "testing results added to PR(link)". -->

## Results
<!--- The main results should be recorded in the appropriate testing results sheet -->
- Compiles and runs for Agave RevB
  - Successfully added WiFi creds to the SD Card
  - Streaming data over wifi to Oscilloscope
  - 🟡 Needs a fix to solve recording session

## Feature Tests
<!--- For each test case, create a unit test in the `EmotiBit Feature Test Protocol` document. -->
<!--- For firmware, the corresponding results recorded in the `EmotiBit Feature Testing Results` sheet. -->
<!--- For software, the corresponding results are recorded in the `EmotiBit Software Testing Records` sheet. -->
<!--- Add the test heading from "EmotiBit Feature Test Protocol" here. -->

## Steps to test
<!--- Import the steps from the `EmotiBit Feature Test Protocol` for quick access for the reviewer -->

# Shared files
- Firmware binary: [Link to firmware binary]
- Other files.

# Checklist to allow merge
- [ ] All dependent repositories used were on branch `master`
- Firmware
  - [ ] Set testingMode to TestingMode::NONE
  - [ ] Set [const bool `DIGITAL_WRITE_DEBUG`](https://github.com/EmotiBit/EmotiBit_FeatherWing/blob/e2ed2dcb70c57c33f70e3a131f82c16627b519df/EmotiBit.h#L58) = false (if set true while testing)
  - [ ] Update version in EmotiBit.h
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation updated


## Screenshots:
