### PR TITLE
Added nullptr check in EmotibitEda_cpp

### DIFF
--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -51,7 +51,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0.feat-FtpServer.1.fix-emotibitEda.1";
+  String firmware_version = "1.9.0.feat-FtpServer.1.fix-emotibitEda.2";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -51,7 +51,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0.feat-FtpServer.1.fix-emotibitEda.0";
+  String firmware_version = "1.9.0.feat-FtpServer.1.fix-emotibitEda.1";
 
 
 

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -51,7 +51,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0.feat-FtpServer.1";
+  String firmware_version = "1.9.0.feat-FtpServer.1.fix-emotibitEda.0";
 
 
 

--- a/EmotiBitEda.cpp
+++ b/EmotiBitEda.cpp
@@ -545,8 +545,8 @@ bool EmotiBitEda::writeInfoJson(File &jsonFile)
 		setups[i]["eda_series_resistance"] = _constants.edaSeriesResistance;
 		setups[i]["adc_bits"] = _constants.adcBits;
 		setups[i]["enable_digital_filter"] = _constants.enableDigitalFilter;
-		setups[i]["samples_averaged"] = _edlOversampBuffer->capacity();
-		setups[i]["oversampling_rate"] = _edlOversampBuffer->capacity() * _constants.samplingRate;
+		if(_edlOversampBuffer) setups[i]["samples_averaged"] = _edlOversampBuffer->capacity();
+		if(_edlOversampBuffer) setups[i]["oversampling_rate"] = _edlOversampBuffer->capacity() * _constants.samplingRate;
 		if (_emotibitVersion >= EmotiBitVersionController::EmotiBitVersion::V04A)
 		{
 			setups[i]["eda_transform_slope"] = _constants_v4_plus.edaTransformSlope;

--- a/EmotiBitEda.cpp
+++ b/EmotiBitEda.cpp
@@ -156,6 +156,7 @@ bool EmotiBitEda::stageCalibStorage(EmotiBitNvmController * nvmController, Strin
 				EmotiBitEdaCalibration::print(rawVals);
 
 				Serial.println("Staging to write...");
+				if(nvmController == nullptr) return false;
 				uint8_t status = nvmController->stageToWrite(EmotiBitNvmController::DataType::EDA, dataVersion, sizeof(EmotiBitEdaCalibration::RawValues_V2), (uint8_t *)(&rawVals), autoSync);
 
 				if (status == (uint8_t)EmotiBitNvmController::Status::SUCCESS)
@@ -196,6 +197,7 @@ bool EmotiBitEda::stageCalibLoad(EmotiBitNvmController * nvmController, bool aut
 	uint8_t dataVersion;
 	uint32_t dataSize;
 	uint8_t* data = nullptr;
+	if(nvmController == nullptr) return false;
 	uint8_t status = nvmController->stageToRead(EmotiBitNvmController::DataType::EDA, dataVersion, dataSize, data, autoSync);
 
 	if (status != (uint8_t)EmotiBitNvmController::Status::SUCCESS || dataSize == 0)
@@ -259,6 +261,7 @@ uint8_t EmotiBitEda::readData()
 
 	if (_emotibitVersion >= EmotiBitVersionController::EmotiBitVersion::V04A)
 	{
+		if(_edlOversampBuffer == nullptr || _edlBuffer == nullptr) return 16; // BufferFloat::ERROR_PTR_NULL = 16. But, any non-zero value sohuld work.
 		// Code to debug missed conversions
 		//static uint16_t completed = 0;
 		//static uint16_t total = 0;
@@ -309,7 +312,7 @@ uint8_t EmotiBitEda::readData()
 	else
 	{
 		// Reads EDA data from ADC
-
+		if(_edlOversampBuffer == nullptr || _edrOversampBuffer == nullptr || _edlBuffer == nullptr || _edrBuffer == nullptr) return 16; // BufferFloat::ERROR_PTR_NULL = 16. But, any non-zero value sohuld work.
 		// Check EDL and EDR voltages for saturation
 #if defined(ARDUINO_FEATHER_ESP32)
 		// analogReadMillis is much more accurate for ESP
@@ -356,6 +359,7 @@ bool EmotiBitEda::processData()
 {
 	if (_emotibitVersion >= EmotiBitVersionController::EmotiBitVersion::V04A)
 	{
+		if(_edlBuffer == nullptr || _edaBuffer == nullptr) return false;
 		size_t n;
 		float * edlData;
 		float edaTemp;
@@ -385,6 +389,7 @@ bool EmotiBitEda::processData()
 	}
 	else
 	{
+		if(_edlBuffer == nullptr || _edrBuffer == nullptr || _edaBuffer == nullptr) return false;
 		size_t n, edlN, edrN;
 		float *edlData, *edrData;
 		uint32_t edlTs, edrTs;
@@ -522,6 +527,7 @@ bool EmotiBitEda::processData()
 
 bool EmotiBitEda::writeInfoJson(File &jsonFile)
 {
+	if(_edlOversampBuffer == nullptr) return false;
 	const uint16_t bufferSize = 1024;
 	{
 		// Parse the root object
@@ -545,8 +551,8 @@ bool EmotiBitEda::writeInfoJson(File &jsonFile)
 		setups[i]["eda_series_resistance"] = _constants.edaSeriesResistance;
 		setups[i]["adc_bits"] = _constants.adcBits;
 		setups[i]["enable_digital_filter"] = _constants.enableDigitalFilter;
-		if(_edlOversampBuffer) setups[i]["samples_averaged"] = _edlOversampBuffer->capacity();
-		if(_edlOversampBuffer) setups[i]["oversampling_rate"] = _edlOversampBuffer->capacity() * _constants.samplingRate;
+		setups[i]["samples_averaged"] = _edlOversampBuffer->capacity();
+		setups[i]["oversampling_rate"] = _edlOversampBuffer->capacity() * _constants.samplingRate;
 		if (_emotibitVersion >= EmotiBitVersionController::EmotiBitVersion::V04A)
 		{
 			setups[i]["eda_transform_slope"] = _constants_v4_plus.edaTransformSlope;
@@ -639,6 +645,7 @@ void EmotiBitEda::setAdcIsrOffsetCorr(float isrOffsetCorr)
 
 void EmotiBitEda::processElectrodermalResponse(EmotiBit* emotibit)
 {
+	if(_edaBuffer == nullptr || emotibit == nullptr) return;
 	static const float samplingFrequency = _constants.samplingRate;
 	static const float timePeriod = 1.f / samplingFrequency; // in secs
 	static const float scrFreqTimePeriod = _constants.EDA_SAMPLES_PER_SCR_FREQ_OUTPUT  * timePeriod; // timePeriod of the signal scr:FREQ

--- a/EmotiBitEda.cpp
+++ b/EmotiBitEda.cpp
@@ -261,7 +261,7 @@ uint8_t EmotiBitEda::readData()
 
 	if (_emotibitVersion >= EmotiBitVersionController::EmotiBitVersion::V04A)
 	{
-		if(_edlOversampBuffer == nullptr || _edlBuffer == nullptr) return 16; // BufferFloat::ERROR_PTR_NULL = 16. But, any non-zero value sohuld work.
+		if(_edlOversampBuffer == nullptr || _edlBuffer == nullptr) return (uint8_t) BufferFloat::ERROR_PTR_NULL; // BufferFloat::ERROR_PTR_NULL = 16. But, any non-zero value sohuld work.
 		// Code to debug missed conversions
 		//static uint16_t completed = 0;
 		//static uint16_t total = 0;
@@ -312,7 +312,7 @@ uint8_t EmotiBitEda::readData()
 	else
 	{
 		// Reads EDA data from ADC
-		if(_edlOversampBuffer == nullptr || _edrOversampBuffer == nullptr || _edlBuffer == nullptr || _edrBuffer == nullptr) return 16; // BufferFloat::ERROR_PTR_NULL = 16. But, any non-zero value sohuld work.
+		if(_edlOversampBuffer == nullptr || _edrOversampBuffer == nullptr || _edlBuffer == nullptr || _edrBuffer == nullptr) return (uint8_t) BufferFloat::ERROR_PTR_NULL; // BufferFloat::ERROR_PTR_NULL = 16. But, any non-zero value sohuld work.
 		// Check EDL and EDR voltages for saturation
 #if defined(ARDUINO_FEATHER_ESP32)
 		// analogReadMillis is much more accurate for ESP
@@ -389,7 +389,7 @@ bool EmotiBitEda::processData()
 	}
 	else
 	{
-		if(_edlBuffer == nullptr || _edrBuffer == nullptr || _edaBuffer == nullptr) return false;
+		if(_edlBuffer == nullptr || _edrBuffer == nullptr || _edaBuffer == nullptr || _edrOversampBuffer == nullptr) return false;
 		size_t n, edlN, edrN;
 		float *edlData, *edrData;
 		uint32_t edlTs, edrTs;

--- a/EmotiBitEda.cpp
+++ b/EmotiBitEda.cpp
@@ -261,7 +261,7 @@ uint8_t EmotiBitEda::readData()
 
 	if (_emotibitVersion >= EmotiBitVersionController::EmotiBitVersion::V04A)
 	{
-		if(_edlOversampBuffer == nullptr || _edlBuffer == nullptr) return (uint8_t) BufferFloat::ERROR_PTR_NULL; // BufferFloat::ERROR_PTR_NULL = 16. But, any non-zero value sohuld work.
+		if(_edlOversampBuffer == nullptr || _edlBuffer == nullptr) return (uint8_t) BufferFloat::ERROR_PTR_NULL;
 		// Code to debug missed conversions
 		//static uint16_t completed = 0;
 		//static uint16_t total = 0;
@@ -312,7 +312,7 @@ uint8_t EmotiBitEda::readData()
 	else
 	{
 		// Reads EDA data from ADC
-		if(_edlOversampBuffer == nullptr || _edrOversampBuffer == nullptr || _edlBuffer == nullptr || _edrBuffer == nullptr) return (uint8_t) BufferFloat::ERROR_PTR_NULL; // BufferFloat::ERROR_PTR_NULL = 16. But, any non-zero value sohuld work.
+		if(_edlOversampBuffer == nullptr || _edrOversampBuffer == nullptr || _edlBuffer == nullptr || _edrBuffer == nullptr) return (uint8_t) BufferFloat::ERROR_PTR_NULL;
 		// Check EDL and EDR voltages for saturation
 #if defined(ARDUINO_FEATHER_ESP32)
 		// analogReadMillis is much more accurate for ESP


### PR DESCRIPTION
# Description
- Added nullptr checks. These were causing a crash on the agave board.


# Requirements
- None


# Issues Referenced
<!-- If Any -->
- Fixes #293 

# Documentation update
- None

# Testing
- This is a minor patch, so there is no test added in the Feature test protocol doc.
  - In the future, when we do implement a mechanism of "selectively setting up sensors", we will probably add a test to check that the fw does not crash if using a sensors module not setup
- For now, i just test it by bypassing eda setup in the `setup()`
```
 // Setup EDA
	#if(0) // #if defined out
	{
	Serial.println("\nInitializing EDA... ");
	if (emotibitEda.setup(_hwVersion, _samplingRates.eda / ((float)_samplesAveraged.eda), &eda, &edl, &edr, _EmotiBit_i2c, &edlBuffer, &edrBuffer))
	{
		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::ADC_INIT, EmotiBitFactoryTest::TypeTag::TEST_PASS);
		Serial.println("Completed");
	}
	else
	{
		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::ADC_INIT, EmotiBitFactoryTest::TypeTag::TEST_FAIL);
		Serial.println(factoryTestSerialOutput);
		Serial.println("failed");
	}
	}
	Serial.println("\nLoading EDA calibration... ");
	if (emotibitEda.stageCalibLoad(&_emotibitNvmController, true))
	{
		Serial.println("Completed");
	}
	else
	{
		Serial.println("failed");
	}
	#endif
```
and the oscilloscope continued set up and continued normal function + recording without eda (which was previously crashing for the agave board)
![image](https://github.com/EmotiBit/EmotiBit_FeatherWing/assets/31810812/e958a114-5085-4fdc-a9c2-21e721d1d84b)
