### PR TITLE
Changed HR precision to 2

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -3275,7 +3275,7 @@ void EmotiBit::processHeartRate()
 
 			// Add packets to output
 			addPacket(beatTime, EmotiBitPacket::TypeTag::INTER_BEAT_INTERVAL, &interBeatInterval, APERIODIC_DATA_LEN);
-			addPacket(beatTime, EmotiBitPacket::TypeTag::HEART_RATE, &heartRate, APERIODIC_DATA_LEN);
+			addPacket(beatTime, EmotiBitPacket::TypeTag::HEART_RATE, &heartRate, APERIODIC_DATA_LEN, 2);
 				
 			// reset interBeatCount
 			interBeatSampleCount = 0;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -50,7 +50,7 @@ public:
 
 
 
-  String firmware_version = "1.9.0";
+  String firmware_version = "1.9.0.fix-hrPrecision.0";
 
 
 


### PR DESCRIPTION
# Description
Changed `HR` precision from 0 to 2

# Issues Referenced
#303

# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->
<!--- If another **linked PR** is the main PR for this bug-fix/ feature-add, you may then remove this testing section and add a link to the main PR here with the explicit statement "testing results added to PR(link)". -->
`HR` packets should have 2 decimal points

# Shared files
- [1.9.0.fix-hrPrecision.0.zip](https://github.com/EmotiBit/EmotiBit_FeatherWing/files/14749914/1.9.0.fix-hrPrecision.0.zip)

