### PR TITLE
Feat led controller

### DIFF
--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -12,7 +12,7 @@
 #include <EmotiBit_Si7013.h>
 #include <BMI160Gen.h>
 #include <MAX30105.h>
-#include <EmotiBit_NCP5623.h>
+#include "EmotiBitLedController.h"
 #include <SparkFun_MLX90632_Arduino_Library.h>
 #include "DoubleBufferFloat.h"
 #include <ArduinoJson.h>
@@ -53,7 +53,7 @@ public:
 
 
 
-  String firmware_version = "1.11.1";
+  String firmware_version = "1.11.1.feat-LedController.0";
 
 
 
@@ -249,13 +249,6 @@ public:
   	TIME_FILESYNC  //time taken for file syncing
   };
 
-  //TODO: Make enum classs for led's
-  enum class Led {
-	  RED = 1,
-	  BLUE,
-	  YELLOW
-  };
-
   enum class BattLevel {
 	  THRESHOLD_HIGH = 50, // Set thresholds for changing led indication on board for battery
 	  //THRESHOLD_MED  = 15,
@@ -280,7 +273,7 @@ public:
 	PPGSettings ppgSettings;
 	IMUSettings imuSettings;
 	MAX30105 ppgSensor;
-	NCP5623 led;
+	EmotiBitLedController led;
 	MLX90632 thermopile;
 	EmotiBitEda emotibitEda;
 	EmotiBitNvmController _emotibitNvmController;
@@ -387,7 +380,7 @@ public:
 		bool MAX30101 = false;
 		bool BMI160 = false;
 		bool BMM150 = false;
-		bool NCP5623 = false;
+		bool NCP5623 = false;  // ToDo: Move this setting to the LED controller
 		bool MLX90632 = false;
 	} chipBegun;
 	

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -53,7 +53,7 @@ public:
 
 
 
-  String firmware_version = "1.11.1.feat-LedController.0";
+  String firmware_version = "1.11.1.feat-LedController.1";
 
 
 

--- a/EmotiBitLedController.cpp
+++ b/EmotiBitLedController.cpp
@@ -1,0 +1,107 @@
+/**************************************************************************/
+/*!
+    @file     EmotiBitLedController.cpp
+    @author   Nitin Nair (EmotiBit)
+
+    @mainpage LED handler for EmotiBit
+
+    @section intro_sec Introduction
+
+    This class handles LEDs on EmotiBit.
+
+		EmotiBit invests time and resources providing this open source code,
+    please support EmotiBit and open-source hardware by purchasing
+    products from EmotiBit!
+
+    @section author Author
+
+    Written by Nitin Nair for EmotiBit.
+
+    @section  HISTORY
+
+    v0.1  - First release
+
+    @section license License
+
+    BSD license, all text here must be included in any redistribution
+*/
+/**************************************************************************/
+#include "EmotiBitLedController.h"
+
+
+bool EmotiBitLedController::begin(TwoWire* emotibitI2c, EmotiBitVersionController::EmotiBitVersion hwVersion)
+{
+    bool status;
+    if((uint8_t) hwVersion > (uint8_t)EmotiBitVersionController::EmotiBitVersion::V05C)
+    {
+        // EmotiBit HW v6+
+        status = ncp5623.begin(*emotibitI2c, NCP5623_C_DEFAULT_ADDR);
+    }
+    else
+    {
+        status = ncp5623.begin(*emotibitI2c, NCP5623_B_DEFAULT_ADDR);
+    }
+    
+    // ToDo: version control this setup specific to EmotiBit HW with NCP
+    // set NCP5623 settings
+    // ToDo: expose NCP driver settings to function signature
+    if (settingsNCP5623.driverCurrent > 0)
+    {
+        // ToDo: NCP driver update to avoid I2C communication in setCurrent
+        ncp5623.setCurrent(settingsNCP5623.driverCurrent);
+    }
+    ncp5623.setLEDpwm((uint8_t)Led::RED, settingsNCP5623.pwmVal);
+    ncp5623.setLEDpwm((uint8_t)Led::BLUE, settingsNCP5623.pwmVal);
+    ncp5623.setLEDpwm((uint8_t)Led::YELLOW, settingsNCP5623.pwmVal);
+    setState(Led::RED, false);
+    setState(Led::BLUE, false);
+    setState(Led::YELLOW, false);
+    update();
+    // ToDo: expose other elements of the NCP settings to the LedController
+    return status;
+}
+
+bool EmotiBitLedController::setState(Led led, bool state, bool updateNow)
+{
+    _ledStatus[(int)led].state = state;
+    _ledStatus[(int)led].isChanged = true;
+    if(updateNow)
+    {
+        return update();
+    }
+    return true;
+}
+
+bool EmotiBitLedController::getState(Led led)
+{
+    return _ledStatus[(int)led].state;
+}
+
+bool EmotiBitLedController::updateNcp()
+{
+    // update the internal class of the driver
+    for (uint8_t i = 0;i<Led::length;i++)
+    {
+        if(_ledStatus[i].isChanged)
+        {
+            ncp5623.setLED(getNcpMappedLed((Led)i), _ledStatus[i].state);
+        }
+    }
+    
+    // Communicate with the driver and write the changes to chip 
+    ncp5623.send();
+    // ToDo: change the function signature of NCP5623::send() to return i2c error so that it can be propagated upstream.
+    return true;
+}
+
+bool EmotiBitLedController::update()
+{
+    // this will become version controlled if we change the LED driver on EmotiBit
+    return updateNcp();
+}
+
+uint8_t EmotiBitLedController::getNcpMappedLed(Led led)
+{
+    // ToDo: bounds check
+    return ledToNcpMap[(int)led];
+}

--- a/EmotiBitLedController.cpp
+++ b/EmotiBitLedController.cpp
@@ -77,14 +77,15 @@ bool EmotiBitLedController::getState(Led led)
     return _ledStatus[(int)led].state;
 }
 
-bool EmotiBitLedController::updateNcp()
+bool EmotiBitLedController::_updateNcp()
 {
     // update the internal class of the driver
     for (uint8_t i = 0;i<Led::length;i++)
     {
         if(_ledStatus[i].isChanged)
         {
-            ncp5623.setLED(getNcpMappedLed((Led)i), _ledStatus[i].state);
+            // ToDo: implement bounds check when referencing array
+            ncp5623.setLED(ledToNcpMap[i], _ledStatus[i].state);
         }
     }
     
@@ -97,11 +98,5 @@ bool EmotiBitLedController::updateNcp()
 bool EmotiBitLedController::update()
 {
     // this will become version controlled if we change the LED driver on EmotiBit
-    return updateNcp();
-}
-
-uint8_t EmotiBitLedController::getNcpMappedLed(Led led)
-{
-    // ToDo: bounds check
-    return ledToNcpMap[(int)led];
+    return _updateNcp();
 }

--- a/EmotiBitLedController.h
+++ b/EmotiBitLedController.h
@@ -40,20 +40,23 @@ public:
     {
         bool state = false;
         bool isChanged = false;
-    }_ledStatus[Led::length];
+    } _ledStatus[Led::length];
     
     /*!
      * @brief Map LedController to NCP led numbers.
               The NCP led number are taken from the driver implementation.
     */
-    const uint8_t ledToNcpMap[Led::length] = { 1,  // Red
-                                    2,  // Blue
-                                    3}; // Yellow
+    const uint8_t ledToNcpMap[Led::length] = 
+                                    { 
+                                        1,  // Red
+                                        2,  // Blue
+                                        3   // Yellow
+                                    }; 
 
     struct SettingsNCP5623{
         uint8_t driverCurrent = 1;
         uint8_t pwmVal = 8;
-    }settingsNCP5623;
+    } settingsNCP5623;
     
     NCP5623 ncp5623;
 
@@ -82,12 +85,6 @@ public:
      * @return state of the LED can be true (ON) or false (OFF)
     */
     bool getState(Led led);
-
-    /*!
-     * @brief Function to communicate with the NCP5623 driver
-     * @return true is successful, else false
-    */
-    bool updateNcp();
     
     /*!
      * @brief Function to update the LEDs with the internal LED state. Call with caution as it may involce communicating with the driver.
@@ -102,5 +99,12 @@ public:
      * @return Returns the NCP driver LED value
     */
     uint8_t getNcpMappedLed(Led led);
+
+private:
+    /*!
+     * @brief Function to communicate with the NCP5623 driver
+     * @return true if successful, else false
+    */
+    bool updateNcp();
 };
 #endif

--- a/EmotiBitLedController.h
+++ b/EmotiBitLedController.h
@@ -1,0 +1,106 @@
+/**************************************************************************/
+/*!
+    @file     EmotiBitLedController.h
+
+    This class handles LEDs on EmotiBit.
+
+    EmotiBit invests time and resources providing this open source code,
+    please support EmotiBit and open-source hardware by purchasing
+    products from EmotiBit!
+
+    Written by Nitin Nair for EmotiBit.
+
+    BSD license, all text here must be included in any redistribution
+*/
+/**************************************************************************/
+#ifndef EMOTIBIT_LED_CONTROLLER
+#define EMOTIBIT_LED_CONTROLLER
+#include <Arduino.h>
+#include "EmotiBitVersionController.h"
+#include "EmotiBit_NCP5623.h"
+
+class EmotiBitLedController
+{
+public:
+    /*!
+     * @brief enumerator for LEDs on EmotiBit 
+    */
+    enum Led
+    {
+        RED = 0,
+        BLUE, 
+        YELLOW,
+        length 
+    };
+
+    /*!
+     * @brief struct to hold current state of LEDs on EmotiBit
+    */
+    struct LedStatus
+    {
+        bool state = false;
+        bool isChanged = false;
+    }_ledStatus[Led::length];
+    
+    /*!
+     * @brief Map LedController to NCP led numbers.
+              The NCP led number are taken from the driver implementation.
+    */
+    const uint8_t ledToNcpMap[Led::length] = { 1,  // Red
+                                    2,  // Blue
+                                    3}; // Yellow
+
+    struct SettingsNCP5623{
+        uint8_t driverCurrent = 1;
+        uint8_t pwmVal = 8;
+    }settingsNCP5623;
+    
+    NCP5623 ncp5623;
+
+public:
+
+    /*!
+     * @brief Setup the LedController
+     * @param emotibitI2c i2c instance on EmotiBit
+     * @param hwVersion EmotiBit Hardware Version
+     * @return true is setup successful, else false
+    */
+   bool begin(TwoWire* emotibitI2c, EmotiBitVersionController::EmotiBitVersion hwVersion);
+
+    /*!
+     * @brief set the state of the LED
+     * @param led the led to set
+     * @param state State LED is set to
+     * @param updateNow Specify if the physical state should be updated immediately. Warning: EmotiBit LED driver should only be communicated with in the ISR if running stock EmotiBit FW.
+     * @return true if success, else false
+    */
+    bool setState(Led led, bool state, bool updateNow = false);
+
+    /*!
+     * @brief Function to get the State of the LED
+     * @param led Get state of this led
+     * @return state of the LED can be true (ON) or false (OFF)
+    */
+    bool getState(Led led);
+
+    /*!
+     * @brief Function to communicate with the NCP5623 driver
+     * @return true is successful, else false
+    */
+    bool updateNcp();
+    
+    /*!
+     * @brief Function to update the LEDs with the internal LED state. Call with caution as it may involce communicating with the driver.
+              EmotiBit stock FW only allows I2C communication during ISR.
+     * @return true is successful, else false
+    */
+    bool update();
+    
+    /*!
+     * @brief function to get the LED mapping to the NCP driver outputs
+     * @param led led to get the mapping for
+     * @return Returns the NCP driver LED value
+    */
+    uint8_t getNcpMappedLed(Led led);
+};
+#endif

--- a/EmotiBitLedController.h
+++ b/EmotiBitLedController.h
@@ -66,7 +66,7 @@ public:
      * @brief Setup the LedController
      * @param emotibitI2c i2c instance on EmotiBit
      * @param hwVersion EmotiBit Hardware Version
-     * @return true is setup successful, else false
+     * @return true if setup successful, else false
     */
    bool begin(TwoWire* emotibitI2c, EmotiBitVersionController::EmotiBitVersion hwVersion);
 
@@ -87,24 +87,17 @@ public:
     bool getState(Led led);
     
     /*!
-     * @brief Function to update the LEDs with the internal LED state. Call with caution as it may involce communicating with the driver.
-              EmotiBit stock FW only allows I2C communication during ISR.
-     * @return true is successful, else false
+     * @brief Function to update the LEDs with the internal LED state. Call with caution as it may involve communicating with the driver.
+              EmotiBit stock FW only allows I2C communication ONLY DURING ISR. Communicating outside ISR may cause collision on the I2C line.
+     * @return true if successful, else false
     */
     bool update();
-    
-    /*!
-     * @brief function to get the LED mapping to the NCP driver outputs
-     * @param led led to get the mapping for
-     * @return Returns the NCP driver LED value
-    */
-    uint8_t getNcpMappedLed(Led led);
 
 private:
     /*!
      * @brief Function to communicate with the NCP5623 driver
      * @return true if successful, else false
     */
-    bool updateNcp();
+    bool _updateNcp();
 };
 #endif

--- a/EmotiBitVersionController.cpp
+++ b/EmotiBitVersionController.cpp
@@ -67,6 +67,10 @@ const char* EmotiBitVersionController::getHardwareVersion(EmotiBitVersion versio
 	{
 		return "V05c\0";
 	}
+	else if (version == EmotiBitVersion::V06A)
+	{
+		return "V06a\0";
+	}
 	else
 	{
 		return "NA\0";

--- a/EmotiBitVersionController.h
+++ b/EmotiBitVersionController.h
@@ -105,6 +105,7 @@ public:
 		V03B = 5,
 		V04A = 6,
 		V05C = 7,
+		V06A = 8,
 		length
 	};
 

--- a/testing/LedController/FactoryTestPrompt/platformio.ini
+++ b/testing/LedController/FactoryTestPrompt/platformio.ini
@@ -8,7 +8,6 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-; ToDo: add support for Feather M0
 [env:featheresp32]
 platform = espressif32
 board = featheresp32
@@ -19,5 +18,3 @@ lib_dir = ../../../../
 
 [env]
 lib_ldf_mode = deep+
-
-; ToDo: add a script to rename firmware.bin to <UNIT_TEST_NAME>_<FEATHER_PLATFORM>.bin

--- a/testing/LedController/LedController-testLedSequence/LedController-testLedSequence.code-workspace
+++ b/testing/LedController/LedController-testLedSequence/LedController-testLedSequence.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/testing/LedController/LedController-testLedSequence/platformio.ini
+++ b/testing/LedController/LedController-testLedSequence/platformio.ini
@@ -1,0 +1,20 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:featheresp32]
+platform = espressif32
+board = featheresp32
+framework = arduino
+
+[platformio]
+lib_dir = ../../../../
+
+[env]
+lib_ldf_mode = deep+

--- a/testing/LedController/LedController-testLedSequence/platformio.ini
+++ b/testing/LedController/LedController-testLedSequence/platformio.ini
@@ -14,6 +14,13 @@ platform = espressif32
 board = featheresp32
 framework = arduino
 
+[env:adafruit_feather_m0]
+platform = atmelsam @3.8.1
+board = adafruit_feather_m0 
+framework = arduino
+build_flags = 
+    -DADAFRUIT_FEATHER_M0
+
 [platformio]
 lib_dir = ../../../../
 

--- a/testing/LedController/LedController-testLedSequence/src/main.cpp
+++ b/testing/LedController/LedController-testLedSequence/src/main.cpp
@@ -37,7 +37,6 @@ void setup()
   }
 
 // setup i2c
-// ToDo: Add support for Feather M0 i2c
 #ifdef ADAFRUIT_FEATHER_M0
 	Serial.println("Setting up I2C For M0...");
 	_EmotiBit_i2c = new TwoWire(&sercom1, EmotiBitVersionController::EMOTIBIT_I2C_DAT_PIN, EmotiBitVersionController::EMOTIBIT_I2C_CLK_PIN);

--- a/testing/LedController/LedController-testLedSequence/src/main.cpp
+++ b/testing/LedController/LedController-testLedSequence/src/main.cpp
@@ -1,0 +1,159 @@
+/*
+This example tests the LEDs on EmotiBit using the Led Controller class.
+The LEDs on EmotiBit should sequentially turn ON and then OFF.
+Tested with EmotiBit v5+Feather ESP32 Huzzah
+*/
+
+#include <Arduino.h>
+#include "EmotiBitLedController.h"
+#include "EmotiBitVersionController.h"
+
+EmotiBitVersionController emotiBitVersionController;
+EmotiBitLedController emotibitLedController;
+TwoWire* _EmotiBit_i2c = nullptr;
+uint32_t i2cRate = 100000;
+int forceHwVersion = -1;
+EmotiBitVersionController::EmotiBitVersion hwVersion = EmotiBitVersionController::EmotiBitVersion::UNKNOWN;
+EmotiBitNvmController emotibitNvmController;
+String emotiBitSku, emotibitDeviceId;
+uint32_t emotibitSerialNumber; 
+
+void setup()
+{
+  Serial.begin(115200);  
+
+  // EmotiBit Ready
+  if (emotiBitVersionController.isEmotiBitReady())
+  {
+    Serial.println("EmotiBit ready");
+  }
+  else
+  {
+    Serial.println("Version neither detected nor specified. Halting.");
+    while(1);
+  }
+
+// setup i2c
+#ifdef ADAFRUIT_FEATHER_M0
+	Serial.println("Setting up I2C For M0...");
+	_EmotiBit_i2c = new TwoWire(&sercom1, EmotiBitVersionController::EMOTIBIT_I2C_DAT_PIN, EmotiBitVersionController::EMOTIBIT_I2C_CLK_PIN);
+	_EmotiBit_i2c->begin();
+	// ToDo: detect if i2c init fails
+	pinPeripheral(EmotiBitVersionController::EMOTIBIT_I2C_DAT_PIN, PIO_SERCOM);
+	pinPeripheral(EmotiBitVersionController::EMOTIBIT_I2C_CLK_PIN, PIO_SERCOM);
+#elif defined ARDUINO_FEATHER_ESP32
+	_EmotiBit_i2c = new TwoWire(1);
+	Serial.println("Setting up I2C For ESP32...");
+	bool status = _EmotiBit_i2c->begin(EmotiBitVersionController::EMOTIBIT_I2C_DAT_PIN, EmotiBitVersionController::EMOTIBIT_I2C_CLK_PIN);
+	if (status)
+	{
+		Serial.println("I2c setup complete");
+	}
+	else
+	{
+		Serial.println("I2c setup failed");
+	}
+#endif
+
+	Serial.print("Setting clock to ");
+	Serial.println(i2cRate);
+	_EmotiBit_i2c->setClock(i2cRate);
+
+  // init NVM controller
+  Serial.print("Initializing NVM controller: ");
+	if (emotibitNvmController.init(*_EmotiBit_i2c))
+	{
+		Serial.println("success");
+	}
+  else
+  {
+    Serial.println("failure");
+  }
+
+  //get emotibit version details from NVM
+	if (!emotiBitVersionController.getEmotiBitVariantInfo(emotibitNvmController, hwVersion, emotiBitSku, emotibitSerialNumber, emotibitDeviceId))
+	{
+		if (!emotiBitVersionController.detectVariantFromHardware(*(_EmotiBit_i2c), hwVersion, emotiBitSku))
+		{
+			Serial.println("CANNOT IDENTIFY HARDWARE");
+      while(1);
+		}
+	}
+  
+  // chance to override version
+  uint32_t timeSinceWait = millis();
+  Serial.println("To override auto version detection, choose a version below. Press 0 to continue");
+  Serial.println("3. V3\n4. V4\n5. V5\n6. V6");
+  while(!Serial.available())
+  {
+    delay(1000);
+  }
+
+  if(Serial.available())
+  {
+    String input = Serial.readString();
+    forceHwVersion = input.toInt();
+    if(forceHwVersion == 0)
+    {
+      // do nothing
+    }
+    else if(forceHwVersion == 6)
+    {
+      hwVersion = EmotiBitVersionController::EmotiBitVersion::V06A;
+    }
+    else if (forceHwVersion == 5)
+    {
+      hwVersion = EmotiBitVersionController::EmotiBitVersion::V05C;
+    }
+    else if (forceHwVersion == 4)
+    {
+      // ToDo: consider if we even need older EmotiBit versions
+      hwVersion = EmotiBitVersionController::EmotiBitVersion::V04A;
+    }
+    else if (forceHwVersion == 3)
+    {
+      hwVersion = EmotiBitVersionController::EmotiBitVersion::V03B;
+    }
+    else
+    {
+      Serial.println("Invalid input. Reset and start again");
+      while(1);
+    }
+    if(forceHwVersion)
+    {
+      Serial.println("forcing hw version: " + String(EmotiBitVersionController::getHardwareVersion(hwVersion)));
+    }
+  }
+
+
+  // setup ledcontroller
+  if(emotibitLedController.begin(_EmotiBit_i2c, hwVersion))
+  {
+    Serial.println("Led driver initialized");
+  }
+  else
+  {
+    Serial.println("Led driver init failed.");
+    while(1);
+  }
+
+}
+
+void loop()
+{
+  // sequential ON
+  emotibitLedController.setState(EmotiBitLedController::Led::RED, true, true);
+  delay(500);
+  emotibitLedController.setState(EmotiBitLedController::Led::BLUE, true, true);
+  delay(500);
+  emotibitLedController.setState(EmotiBitLedController::Led::YELLOW, true, true);
+  delay(500);
+  
+  // sequential OFF
+  emotibitLedController.setState(EmotiBitLedController::Led::RED, false, true);
+  delay(500);
+  emotibitLedController.setState(EmotiBitLedController::Led::BLUE, false, true);
+  delay(500);
+  emotibitLedController.setState(EmotiBitLedController::Led::YELLOW, false, true);
+  delay(500);
+}


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
- Adds LED controller

# Requirements
- https://github.com/EmotiBit/EmotiBit_NCP5623/pull/4


# Issues Referenced
<!-- If Any -->
- #309 

# Notes for Reviewer
- Add detailed notes explaining code changes, algorithms or any other information that can help the reviewer understand the PR better.

# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->
<!--- If another **linked PR** is the main PR for this bug-fix/ feature-add, you may then remove this testing section and add a link to the main PR here with the explicit statement "testing results added to PR(link)". -->
- Led Controller Unit test (Feather ESP32)
  - Flash the binary linked below (unit test) on a Feather ESP32. You may use the EmotiBit FirmwareInstaller to do so.
  - plug in to serial monitor.
  - reset feather
  - Enter `6` into Serial input when prompted (set `No Line Ending` option). (This way you can start the example on a V5 and force the version to be V6 for testing the change of address for the IC)
      - ![image](https://github.com/EmotiBit/EmotiBit_FeatherWing/assets/31810812/0255d18a-b27c-4f70-a2a7-d4bad646f008)
  - **Notice the LED cycle through**.
- EmotiBit complete FW test
  - Flash the Test Feather with the binary linked below `1.11.1.feat-LedController.0`.
  - Place the frankedn V6 on the test jig as the DUT.
  - Start the factory test. (Follow the SOP if required, but the factory test software should be a sufficient guide)
  - You may use one of the following barcodes in the "barcode scanning phase" (**remember that you need to print the barcode to be able to scan them. the barcode reader cannot read the barcode off a screen**)
  - ![barcode](https://github.com/EmotiBit/EmotiBit_FeatherWing/assets/31810812/27a34a10-1cd4-4339-acfd-1f3863160918)
  - ![barcode(1)](https://github.com/EmotiBit/EmotiBit_FeatherWing/assets/31810812/cb267009-d329-4ca8-8104-ddc3e6847749)


## Results
<!--- The main results should be recorded in the appropriate testing results sheet -->
- Led Controller Unit test
  - V5: ✔️ 
  - V6: ✔️ 
- Complete FW test: 
  - ✔️V5
    - ✔️ Button press
    - ✔️ hibernate
    - ✔️ setup led sequence
    - ✔️ recording
    - ✔️ wifi connection
    - ✔️ Oscilloscope connection
    - ✔️ Factory Test Serial Message prompts
  - ✔️  Franken-F5-V6 

## Feature Tests
<!--- For each test case, create a unit test in the `EmotiBit Feature Test Protocol` document. -->
<!--- For firmware, the corresponding results recorded in the `EmotiBit Feature Testing Results` sheet. -->
<!--- For software, the corresponding results are recorded in the `EmotiBit Software Testing Records` sheet. -->
<!--- Add the test heading from "EmotiBit Feature Test Protocol" here. -->

# Shared files
- Firmware binary
  - LED controller unit test: [LedController-unitTest-FeatherESP32.zip](https://github.com/user-attachments/files/15781108/LedController-testLedSequence-share.zip)
  - EmotiBit_FeatherWing_FW: [1.11.1.feat-LedController.0.zip](https://github.com/user-attachments/files/15892342/1.11.1.feat-LedController.0.zip)



# Checklist to allow merge
- [ ] All dependent repositories used were on branch `master`
- Firmware
  - [ ] Set testingMode to TestingMode::NONE
  - [ ] Set [const bool `DIGITAL_WRITE_DEBUG`](https://github.com/EmotiBit/EmotiBit_FeatherWing/blob/e2ed2dcb70c57c33f70e3a131f82c16627b519df/EmotiBit.h#L58) = false (if set true while testing)
  - [ ] Update version in EmotiBit.h
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation updated


## Screenshots:
