### PR TITLE
Increase available memory on the Feather M0

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -989,11 +989,13 @@ uint8_t EmotiBit::setup(String firmwareVariant)
 		EmotiBitFactoryTest::updateOutputString(factoryTestSerialOutput, EmotiBitFactoryTest::TypeTag::WIFI, EmotiBitFactoryTest::TypeTag::TEST_PASS);
 	}
 	Serial.println(" WiFi setup Completed");
+	#ifdef ARDUINO_FEATHER_ESP32
 	Serial.println("Setting up FTP");
 	Serial.println("Setting Protocol");
   	_fileTransferManager.setProtocol(FileTransferManager::Protocol::FTP);
   	Serial.println("Setting Auth");
   	_fileTransferManager.setFtpAuth("ftp", "ftp");
+	#endif
 
 	setPowerMode(PowerMode::NORMAL_POWER);
 	typeTags[(uint8_t)EmotiBit::DataType::EDA] = EmotiBitPacket::TypeTag::EDA;

--- a/EmotiBit.h
+++ b/EmotiBit.h
@@ -35,7 +35,9 @@
 #include "EmotiBitVariants.h"
 #include "EmotiBitNvmController.h"
 #include "heartRate.h"
+#ifdef ARDUINO_FEATHER_ESP32
 #include "FileTransferManager.h"
+#endif
 #include "EmotiBitConfigManager.h"
 
 class EmotiBit {
@@ -53,7 +55,7 @@ public:
 
 
 
-  String firmware_version = "1.12.0";
+  String firmware_version = "1.12.0.fix-featherM0Mem.1";
 
 
 
@@ -277,7 +279,9 @@ public:
 	MLX90632 thermopile;
 	EmotiBitEda emotibitEda;
 	EmotiBitNvmController _emotibitNvmController;
+	#ifdef ARDUINO_FEATHER_ESP32
 	FileTransferManager _fileTransferManager;
+	#endif
 	EmotiBitConfigManager _emotibitConfigManager;
 
 	int _emotiBitSystemConstants[(int)SystemConstants::length];


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail -->
- Moved `FileTransferManager` definitions to live under ESP board definitions. Since FTP is available only on ESP32, it does not affect Feather M0.
- This adds to the free memory available on the Feather M0, adding stability.

# Requirements
- None


# Issues Referenced
<!-- If Any -->
- None

# Documentation update
None

# Notes for Reviewer
- Add detailed notes explaining code changes, algorithms or any other information that can help the reviewer understand the PR better.

# List of new distributable files (For software PR only)
- Name all new files added with this PR that need to be distributed with the release package. This includes files like `.json`, `.xml` settings files etc.

# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->
<!--- If another **linked PR** is the main PR for this bug-fix/ feature-add, you may then remove this testing section and add a link to the main PR here with the explicit statement "testing results added to PR(link)". -->

## Results
<!--- The main results should be recorded in the appropriate testing results sheet -->
- ✔️ Repeated connect/disconnect
- ✔️ Repeated Record begin/record end tests

## Feature Tests
<!--- For each test case, create a unit test in the `EmotiBit Feature Test Protocol` document. -->
<!--- For firmware, the corresponding results recorded in the `EmotiBit Feature Testing Results` sheet. -->
<!--- For software, the corresponding results are recorded in the `EmotiBit Software Testing Records` sheet. -->
<!--- Add the test heading from "EmotiBit Feature Test Protocol" here. -->

# Shared files
- Firmware binary: [Link to firmware binary]
- Other files.

# Checklist to allow merge
- [x] All dependent repositories used were on branch `master`
- Firmware
  - [ ] Set testingMode to TestingMode::NONE
  - [ ] Set [const bool `DIGITAL_WRITE_DEBUG`](https://github.com/EmotiBit/EmotiBit_FeatherWing/blob/e2ed2dcb70c57c33f70e3a131f82c16627b519df/EmotiBit.h#L58) = false (if set true while testing)
  - [ ] Update version in EmotiBit.h
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation updated


## Screenshots:
