### PR TITLE
refactored appendTestData

### DIFF
--- a/EmotiBit.cpp
+++ b/EmotiBit.cpp
@@ -3837,27 +3837,14 @@ void EmotiBit::updateBatteryIndication(float battPercent)
 	}
 }
 
+//used to access each type tag locally in EmotiBit Packet
+const char* typeTags[(uint8_t)EmotiBit::DataType::length];
+
 void EmotiBit::appendTestData(String &dataMessage, uint16_t &packetNumber)
 {
-	for (uint8_t t = ((uint8_t)EmotiBit::DataType::DATA_CLIPPING) + 1; t < (uint8_t)DataType::length; t++)
-	{
-		String payload;
-		int m = 5;
-		int n = 2;
-		for (int i = 0; i < m; i++)
-		{
-			int k;
-			for (int j = 0; j < n; j++)
-			{
-				if (i > 0 || j > 0)
-				{
-					payload += EmotiBitPacket::PAYLOAD_DELIMITER;
-				}
-				k = i * 250 / m + random(50);
-				payload += k;
-			}
-		}
-		dataMessage += EmotiBitPacket::createPacket(typeTags[t], packetNumber++, payload, m * n);
+	//Refactored to use EmotiBitPacket::appendTestDataMessage() to allow for cross platform testing
+	if (_sdWrite){ //only send test data if we are recording
+		EmotiBitPacket::appendTestDataMessage(dataMessage, packetNumber, typeTags, ((uint8_t)EmotiBit::DataType::DATA_CLIPPING) + 1, (uint8_t)EmotiBit::DataType::length);
 	}
 }
 


### PR DESCRIPTION
# Description

- Refactoring appendTestData so it lives in [EmotiBit_XPlat_Utils](https://github.com/EmotiBit/EmotiBit_XPlat_Utils)

# Requirements

- PR [1.12.1.feat-appendTestData](https://github.com/EmotiBit/EmotiBit_XPlat_Utils/tree/1.12.1.feat-appendTestData)


# Notes for Reviewer
- This change removes the previous sawtooth logic, replacing it with a function call to "appendTestDataMessage" in EmotiBitPacket which will be building the test packets for EmotiBit.cpp. It is also wrapped in a conditional to check if recording has begun, ensuring our SD card files follow the determined results from EmotiBitPacket


# Testing
<!--- The testing results should be added to the main PR behind this bug-fix/ feature-add -->
<!--- If another **linked PR** is the main PR for this bug-fix/ feature-add, you may then remove this testing section and add a link to the main PR here with the explicit statement "testing results added to PR(link)". -->

## Results
<!--- The main results should be recorded in the appropriate testing results sheet -->
- Synopsis of results, details if required.

## Feature Tests
<!--- For each test case, create a unit test in the `EmotiBit Feature Test Protocol` document. -->
<!--- For firmware, the corresponding results recorded in the `EmotiBit Feature Testing Results` sheet. -->
<!--- For software, the corresponding results are recorded in the `EmotiBit Software Testing Records` sheet. -->
<!--- Add the test heading from "EmotiBit Feature Test Protocol" here. -->

# Shared files
- Firmware binary: [Link to firmware binary]
- Other files.

# Checklist to allow merge
- [ ] All dependent repositories used were on branch `master`
- Software
  - [ ] Get approval from the reviewer
  - [ ] Passed testing on Windows
  - [ ] Passed testing on macOS *(for major changes/GUI changes/ PRs adding files distributed with the EmotiBit software)*
  - [ ] Passed testing on linux (ubuntu) *(for major changes/GUI changes/ PRs adding files distributed with the EmotiBit software)*
  - [ ] Update software bundle version in `ofxEmotiBitVersion.h`
- Firmware
  - [ ] Set testingMode to TestingMode::NONE
  - [ ] Set [const bool `DIGITAL_WRITE_DEBUG`](https://github.com/EmotiBit/EmotiBit_FeatherWing/blob/e2ed2dcb70c57c33f70e3a131f82c16627b519df/EmotiBit.h#L58) = false (if set true while testing)
  - [ ] Update version in EmotiBit.h
  - [ ] Update library.properties to the correct version (should match EmotiBit.h)
- [ ] doxygen style comments included for new code snippets
- [ ] Required documentation updated


## Screenshots:
